### PR TITLE
/posts and /media GET and pagination specs

### DIFF
--- a/app/api/v1/resources/media.rb
+++ b/app/api/v1/resources/media.rb
@@ -29,7 +29,10 @@ module API::V1
           authorize! :view, ::Media
           require_scope! :'view:media'
 
-          present Media.order(created_at: :desc).page(page).per(per_page), with: Entities::Media
+          @media = ::Media.order(created_at: :desc).page(page).per(per_page)
+
+          set_pagination_headers(@media, 'media')
+          present @media, with: Entities::Media
         end
 
         desc 'Search for media'

--- a/app/api/v1/resources/posts.rb
+++ b/app/api/v1/resources/posts.rb
@@ -44,7 +44,10 @@ module API::V1
           require_scope! :'view:posts'
           authorize! :view, Post
 
-          present Post.page(page).per(per_page), with: Entities::Post
+          @posts = Post.page(page).per(per_page)
+
+          set_pagination_headers(@posts, 'posts')
+          present @posts, with: Entities::Post
         end
 
         desc 'Show published posts'

--- a/spec/api/v1/resources/media_spec.rb
+++ b/spec/api/v1/resources/media_spec.rb
@@ -9,6 +9,31 @@ describe API::Resources::Media do
     login_as user
   end
 
+  describe 'GET /media' do
+
+    it 'returns an empty array if there is no media' do
+      get '/api/v1/media'
+      response.should be_success
+      JSON.parse(response.body).should == []
+    end
+
+    it 'should return two media items' do
+      2.times { create(:media) }
+      get '/api/v1/media'
+      response.should be_success
+      JSON.parse(response.body).count.should == 2
+    end
+
+    it 'should return paginated results' do
+      5.times { create(:media) }
+      get '/api/v1/media?per_page=2'
+      response.should be_success
+      JSON.parse(response.body).count.should == 2
+      response.headers['X-Total-Items'].should == '5'
+      response.headers['Content-Range'].should == 'media 0-1:2/5'
+    end
+  end
+
   describe 'GET /media/:id' do
 
     let(:media) { create(:media) }

--- a/spec/api/v1/resources/posts_spec.rb
+++ b/spec/api/v1/resources/posts_spec.rb
@@ -9,6 +9,33 @@ describe API::Resources::Posts do
     login_as user
   end
 
+  describe 'GET /posts' do
+
+    it 'returns an empty array if there are no posts' do
+      get '/api/v1/posts'
+      response.should be_success
+      JSON.parse(response.body).should == []
+    end
+
+    it 'should return two posts' do
+      post_1 = create(:post)
+      post_2 = create(:post)
+      get '/api/v1/posts'
+      response.should be_success
+      JSON.parse(response.body).count.should == 2
+    end
+
+    it 'should return paginated results' do
+      5.times { create(:post) }
+      get '/api/v1/posts?per_page=2'
+      response.should be_success
+      JSON.parse(response.body).count.should == 2
+      response.headers['X-Total-Items'].should == '5'
+      response.headers['Content-Range'].should == 'posts 0-1:2/5'
+    end
+
+  end
+
   describe 'GET /posts/:id' do
 
     it 'should return the correct post' do

--- a/spec/api_v1_helper.rb
+++ b/spec/api_v1_helper.rb
@@ -1,7 +1,8 @@
 API = API::V1::API
 
 def represent(entity, obj)
-  be_json_eql(entity.new(obj).to_json)
+  obj_json = obj.kind_of?(Array) ? obj.map{ |v| entity.new(v).to_json }.to_json : entity.new(obj).to_json
+  be_json_eql(obj_json)
 end
 
 def application_json


### PR DESCRIPTION
These commits add 6 examples to API specs testing **/posts** and **/media**, including pagination.
