### PR TITLE
Boost title by 2 in post search

### DIFF
--- a/app/assets/javascripts/controllers/posts/grid.js
+++ b/app/assets/javascripts/controllers/posts/grid.js
@@ -9,7 +9,7 @@ angular.module('cortex.controllers.posts.grid', [
     $scope.data = {
         totalServerItems: 0,
         posts: [],
-        query: ''
+        query: null
     };
 
     $scope.postDataParams = new ngTableParams({

--- a/app/models/concerns/searchable_post.rb
+++ b/app/models/concerns/searchable_post.rb
@@ -77,8 +77,7 @@ module SearchablePost
 
   module ClassMethods
     def search_with_params(params, published = nil)
-      query = { query_string: { default_field: "_all", query: self.query_massage(params[:q]) } }
-      sort = { published_at: :desc }
+      query = { query_string: { fields: ['title^2', '_all'], query: self.query_massage(params[:q]) } }
 
       categories = params[:categories]
       job_phase  = params[:job_phase]
@@ -94,7 +93,7 @@ module SearchablePost
       if author; bool[:bool][:must] << self.or_null('author', [author]) end
       if published; bool[:bool][:must] << self.range_search('published_at', 'lte', DateTime.now); bool[:bool][:must] << self.terms_search('draft', [false]) end
 
-      self.search query: bool, sort: sort
+      self.search query: bool
     end
   end
 end


### PR DESCRIPTION
This short changeset boosts Posts' `title` field by 2 when calling search_with_params. 

**It also defaults the method to order by score instead of `published_at`** Sort by relevancy is the expected default behavior of search functionality. To preserve existing sort order on the post grid the default search query is null instead of an empty string (Triggering a non-ES Post query.)
