### PR TITLE
Make space insert a new tag

### DIFF
--- a/app/assets/templates/posts/article/classify.html
+++ b/app/assets/templates/posts/article/classify.html
@@ -38,11 +38,12 @@
 </div>
 
 <div class="tags">
-  <label>Post Tags</label>
+  <label>Post Tags (space starts a new tag, to create a multiword tag use - between words)</label>
 
   <div class="tags-group">
     <tags-input display-property="name"
                 type="text"
+                add-on-space="true"
                 placeholder="Enter relevant tags for this post"
                 ng-model="data.post.tag_list"
                 ng-maxlength="255">


### PR DESCRIPTION
This makes space insert a new tag, and notes this in the text. ngTagsInput does not support a space at the end of the list, which seems to be the problem most users are running in to.
