### PR TITLE
Searchable change for hyphens

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -11,7 +11,7 @@ module Searchable
         return '*' if q.nil? or q.empty?
         result = q.chomp.strip
         return '*' if result.nil? or result.empty?
-        result.index(/\s/).nil? ? "#{result}*" : result
+        result.index(/\s|\-/).nil? ? "#{result}*" : result
       end
 
       def or_null(field, q)


### PR DESCRIPTION
Elasticsearch seems to have odd issues with hyphens.

Given a post named "hyphen-post for testing":

q: hyphen-post\* => NOT FOUND
q: hyphen-post => FOUND
q: hyphen post => FOUND
q: hyphen post\* => FOUND

As such, Searchable will now push through result without a \* if it finds a hyphen.
