### PR TITLE
Require unique slug fix

### DIFF
--- a/app/assets/javascripts/controllers/posts/edit.info.js
+++ b/app/assets/javascripts/controllers/posts/edit.info.js
@@ -8,10 +8,15 @@ angular.module('cortex.controllers.posts.edit.info', [
 .controller('PostsEditInfoCtrl', function($scope, $filter, cortex, delayedBind, currentUser) {
   // Auto-generate slug when title changed and field isn't dirty
   $scope.$watch('data.post.title', function(title) {
-    if ($scope.postForm.slug.$dirty && $scope.postForm.slug) {
+
+    var slug = $filter('slugify')(title);
+
+    var slugOverridden = $scope.postForm.slug.$dirty && $scope.postForm.slug;
+
+    if (slugOverridden) {
       return;
     }
-    $scope.data.post.slug = $filter('slugify')(title);
+    $scope.data.post.slug = slug;
   });
 
   $scope.$watch('data.authorIsUser', function(authorIsUser) {
@@ -32,17 +37,17 @@ angular.module('cortex.controllers.posts.edit.info', [
 
           // A post may have its own slug
           if (post.id === $scope.data.post.id) {
-            $scope.postForm.slug.$error.unavailable = false;
+            $scope.postForm.slug.$setValidity('unavailable', true);
             $scope.data.postWithDuplicateSlug = null;
           }
           else {
-            $scope.postForm.slug.$error.unavailable = true;
+            $scope.postForm.slug.$setValidity('unavailable', false);
             $scope.data.postWithDuplicateSlug = post;
           }
         },
         // Slug unused
         function() {
-          $scope.postForm.slug.$error.unavailable = false;
+          $scope.postForm.slug.$setValidity('unavailable', true);
           $scope.data.postWithDuplicateSlug = null;
         }
     );

--- a/app/assets/templates/posts/edit.html
+++ b/app/assets/templates/posts/edit.html
@@ -76,7 +76,12 @@
                 </div>
               </div>
             </div>
-            <div class="form-status" ng-show="postForm.$invalid && postForm.$dirty">Please fill out the required fields, marked with a *</div>
+            <div class="form-status" ng-show="postForm.$invalid && postForm.$dirty">
+              Please fill out the required fields, marked with a *
+            </div>
+            <div class="form-status" ng-show="postForm.slug.$error.unavailable">
+              Slug "{{ data.post.slug }}" already taken, please use something else
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This changeset prevents the post editor from submitting without a unique slug.

In a nutshell, we had to call `$scope.postForm.slug.$setValidity('unavailable', false)` instead of setting `$scope.postForm.slug.$error.unavailable = true`
