### PR TITLE
Jargon integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jargon-client', git: 'git://github.com/cb-talent-development/jargon-client'
 gem 'grape', '~> 0.9'
 gem 'grape-entity'
 gem 'grape-swagger'
-gem 'doorkeeper'
+gem 'doorkeeper', '~> 1.4.0'
 gem 'redis-rails', '~> 4.0'
 
 # Templating

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/cb-talent-development/jargon-client
-  revision: b163202339812e7980bdf3e0746b7a19898e6c21
+  revision: 78d4709628b70db629deb6b9ff4931e255d0b83e
   specs:
     jargon-client (0.0.1)
       faraday (~> 0.9)
@@ -596,7 +596,7 @@ DEPENDENCIES
   cortex-exceptions
   database_cleaner
   devise
-  doorkeeper
+  doorkeeper (~> 1.4.0)
   dotenv
   elasticsearch-extensions
   elasticsearch-model (~> 0.1)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -66,10 +66,6 @@ class Media < ActiveRecord::Base
 
   private
 
-  def image?
-    attachment_content_type =~ %r{^(image|(x-)?application)/(bmp|gif|jpeg|jpg|pjpeg|png|x-png)$}
-  end
-
   def taxon_type
     Cortex.config.media.allowed_media_types.select{|t| t[:type] == attachment_content_type}[0][:taxon_type]
   end

--- a/app/models/media_types/youtube.rb
+++ b/app/models/media_types/youtube.rb
@@ -3,8 +3,7 @@ class Youtube < Media
   index_name [Rails.env, 'media'].join('_')
   document_type    'media'
   taxon_class_name 'media'
-
-  after_create :fetch_youtube
+  
   store_accessor :meta, :url, :duration, :video_id, :title, :authors, :source_published_at,
                  :source_updated_at, :video_description
 
@@ -20,11 +19,5 @@ class Youtube < Media
 
   def taxon_type
     'VID'
-  end
-
-  private
-
-  def fetch_youtube
-    YoutubeMediaWorker.perform_async(id)
   end
 end

--- a/app/models/observers/media_observer.rb
+++ b/app/models/observers/media_observer.rb
@@ -12,8 +12,12 @@ class MediaObserver < ActiveRecord::Observer
 
   private
 
+  def image?(media)
+    media.attachment_content_type =~ %r{^(image|(x-)?application)/(bmp|gif|jpeg|jpg|pjpeg|png|x-png)$}
+  end
+
   def extract_dimensions(media)
-    return unless image?
+    return unless image?(media)
     tempfile = media.attachment.queued_for_write[:original]
     unless tempfile.nil?
       geometry = Paperclip::Geometry.from_file(tempfile)

--- a/app/models/observers/youtube_observer.rb
+++ b/app/models/observers/youtube_observer.rb
@@ -1,0 +1,11 @@
+class YoutubeObserver < ActiveRecord::Observer
+  def after_create(media)
+    fetch_youtube(media)
+  end
+
+  private
+
+  def fetch_youtube
+    YoutubeMediaWorker.perform_async(id)
+  end
+end

--- a/app/models/onet/occupation.rb
+++ b/app/models/onet/occupation.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: onet_occupations
-#
-#  id          :integer          not null, primary key
-#  soc         :string(255)
-#  title       :string(255)
-#  description :text
-#  created_at  :datetime
-#  updated_at  :datetime
-#
-
 module Onet
   class Occupation < ActiveRecord::Base
     include SearchableOnetOccupation
@@ -23,15 +11,3 @@ module Onet
     }
   end
 end
-
-# == Schema Information
-#
-# Table name: onet_occupations
-#
-#  id          :integer          not null, primary key
-#  soc         :string(255)
-#  title       :string(255)
-#  description :text
-#  created_at  :datetime
-#  updated_at  :datetime
-#

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,9 @@ module Cortex
 
     config.angular_templates.module_name = 'cortex.templates'
     config.i18n.enforce_available_locales = true
-    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/models/media_types #{config.root}/app/models/post_types)
+    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/models/media_types #{config.root}/app/models/post_types #{config.root}/app/models/observers)
     config.active_record.default_timezone = :utc
+    config.active_record.observers = :media_observer, :post_observer, :tenant_observer, :user_observer, :youtube_observer
 
     ActsAsTaggableOn.remove_unused_tags = true
     ActsAsTaggableOn.force_lowercase = true


### PR DESCRIPTION
Jargon integrated into Cortex! Here's what's included:
- Service classes for further abstraction into separate microservice.
- Interface work
- Cortex endpoints for Jargon
- Cortex persistence for Localizations + Locales
- ActiveRecord Observer pattern used to abstract triggers away from Models

What's next?
- Move Service class's business logic to Interactors, mainly to take advantage of Rollback feature.
- Move authorization (current_user, etc) logic to central lib. Current structure is problematic.
- Finalization of interface, once Jargon works - there are some outstanding issues with Localization/Locale creation.
