### PR TITLE
Related Posts Performance Fix

### DIFF
--- a/app/api/v1/resources/posts.rb
+++ b/app/api/v1/resources/posts.rb
@@ -67,6 +67,8 @@ module API
             post = GetPost.call(id: params[:id], published: true).post
             not_found! unless post
             authorize! :view, post
+
+            per_page = params[:per_page] || 5 # Ignore PaginationHelper's/Kaminari's per_page default - too large for related content!
             @posts = post.related(true).page(page).per(per_page).records
             set_pagination_headers(@posts, 'posts')
             present @posts, with: Entities::Post


### PR DESCRIPTION
Reduce the default per_page of posts/feed/:id/related to 5. 25 is a huge burden on the server!
