### PR TITLE
Paperclip AWS v2 Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'doorkeeper', '~> 1.4' # Must upgrade - security risks
 # ActiveRecord
 gem 'rails-observers', '~> 0.1.2'
 gem 'awesome_nested_set', '~> 3.0'
-gem 'paperclip', '~> 4.3'
+gem 'paperclip', git: 'git://github.com/betesh/paperclip', branch: 'aws_v2'
 gem 'paperclip-optimizer', '~> 2.0'
 gem 'acts-as-taggable-on', '~> 3.5'
 gem 'bcrypt', '~> 3.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: git://github.com/betesh/paperclip
+  revision: 57185bc856b6cb2d76ae38cf625469107605ef71
+  branch: aws_v2
+  specs:
+    paperclip (4.3.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (= 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -49,12 +61,12 @@ GEM
     attr_required (1.0.0)
     awesome_nested_set (3.0.2)
       activerecord (>= 4.0.0, < 5)
-    aws-sdk (2.1.12)
-      aws-sdk-resources (= 2.1.12)
-    aws-sdk-core (2.1.12)
+    aws-sdk (2.1.13)
+      aws-sdk-resources (= 2.1.13)
+    aws-sdk-core (2.1.13)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.12)
-      aws-sdk-core (= 2.1.12)
+    aws-sdk-resources (2.1.13)
+      aws-sdk-core (= 2.1.13)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -67,7 +79,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    celluloid (0.16.0)
+    celluloid (0.16.1)
       timers (~> 4.0.0)
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
@@ -93,7 +105,7 @@ GEM
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.5.1)
+    devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -241,7 +253,7 @@ GEM
       json
       multi_json
       request_store (>= 1.0.5)
-    grape (0.12.0)
+    grape (0.13.0)
       activesupport
       builder
       hashie (>= 2.1.0)
@@ -251,7 +263,7 @@ GEM
       rack-accept
       rack-mount
       virtus (>= 1.0.0)
-    grape-entity (0.4.7)
+    grape-entity (0.4.8)
       activesupport
       multi_json (>= 1.3.2)
     grape-swagger (0.10.1)
@@ -279,7 +291,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    haml (4.0.6)
+    haml (4.0.7)
       tilt
     hashie (3.4.2)
     hashie-forbidden_attributes (0.1.1)
@@ -342,7 +354,7 @@ GEM
     mime-types (2.6.1)
     mimemagic (0.3.0)
     mini_portile (0.6.2)
-    minitest (5.7.0)
+    minitest (5.8.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     momentjs-rails (2.10.3)
@@ -364,12 +376,6 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    paperclip (4.3.0)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      cocaine (~> 0.5.5)
-      mime-types
-      mimemagic (= 0.3.0)
     paperclip-optimizer (2.0.0)
       image_optim (~> 0.19)
       paperclip (>= 3.4)
@@ -414,7 +420,7 @@ GEM
     rails-assets-angular (1.3.17)
     rails-assets-angular-animate (1.3.17)
       rails-assets-angular (= 1.3.17)
-    rails-assets-angular-bootstrap (0.13.2)
+    rails-assets-angular-bootstrap (0.13.3)
       rails-assets-angular (>= 1.3.0)
     rails-assets-angular-bootstrap-datetimepicker (0.3.13)
       rails-assets-angular (~> 1.3.14)
@@ -639,7 +645,7 @@ DEPENDENCIES
   newrelic_rpm (~> 3.12.1)
   ng-rails-csrf (~> 0.1.0)
   ngmin-rails (~> 0.4.0)
-  paperclip (~> 4.3)
+  paperclip!
   paperclip-optimizer (~> 2.0)
   paranoia (~> 2.1)
   pg (~> 0.18.2)
@@ -683,3 +689,6 @@ DEPENDENCIES
   uglifier (~> 2.7.1)
   underscore-rails (~> 1.8.3)
   unicorn-rails (~> 2.2.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Switch Paperclip to aws_v2 PR branch for now. Upgrade some gems while I'm at it, too!
