### PR TITLE
Bulk Upload CSV Fix

### DIFF
--- a/app/models/bulk_job.rb
+++ b/app/models/bulk_job.rb
@@ -6,8 +6,8 @@ class BulkJob < ActiveRecord::Base
   has_attached_file :metadata
   has_attached_file :assets
 
-  validates_attachment :metadata, :presence => true,
-                       :content_type => { :content_type => %w(text/csv text/plain) }
+  # Restore content type validation once Rails/Paperclip fixes downloaded CSVs (from S3) content type showing as 'application/force-download'
+  validates_attachment :metadata, :presence => true
   validates_with AttachmentContentTypeValidator, :attributes => :assets, :content_type => 'application/zip'
   validates_presence_of :content_type
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -26,8 +26,6 @@ class Media < ActiveRecord::Base
       :ar_post => {geometry: '1140x', format: :jpg}
   }, processors: [:thumbnail, :paperclip_optimizer], :preserve_files => 'true'
 
-  before_attachment_post_process :can_thumb?
-
   validates_attachment :attachment, :presence => true,
                        :unless => :skip_attachment_validation,
                        :content_type => {:content_type => Cortex.config.media.allowed_media_types.collect{|allowed| allowed[:type]}},

--- a/app/models/observers/media_observer.rb
+++ b/app/models/observers/media_observer.rb
@@ -10,6 +10,10 @@ class MediaObserver < ActiveRecord::Observer
     prevent_consumed_deletion(media)
   end
 
+  def before_attachment_post_process(media)
+    can_thumb?(media)
+  end
+
   private
 
   def image?(media)


### PR DESCRIPTION
- Remove content type validation for `:metadata` on `BulkJob` (this should be restored once there's a fix in place - I believe it's the fault of Rails, when it reads the MIME type of the file it has downloaded from S3).
- Moves a forgotten model hook to its corresponding observer class
