### PR TITLE
Bulk Upload CSV Fix Part Deux

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,8 @@ module Cortex
     config.generators do |generator|
       generator.orm :active_record
     end
+
+    # Needed until there is a better fix for Paperclip. https://github.com/thoughtbot/paperclip/issues/1924#issuecomment-123927367
+    Paperclip.options[:content_type_mappings] = {:csv => 'text/plain'}
   end
 end


### PR DESCRIPTION
The content_type_mappings fix is, unfortunately, necessary for the moment for CSV/bulk upload processing.
