### PR TITLE
CORS: Default to Wildcard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ MEDIA_MAX_SIZE_MB=100
 # CORS Configuration
 #
 
-# CSV allowed origins
-CORS_ALLOWED_ORIGINS=http://localhost:3001
+# CSV allowed origins. Default is '*'
+CORS_ALLOWED_ORIGINS=
 
 # Optional regular expression allowed origin(s)
 CORS_ALLOWED_ORIGINS_REGEX=

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,10 +16,10 @@ module Cortex
     ActsAsTaggableOn.remove_unused_tags = true
     ActsAsTaggableOn.force_lowercase = true
 
-    # Insert Rack::CORS as one of the first middleware
-    config.middleware.insert_after Rack::Sendfile, Rack::Cors do
+    # Insert Rack::CORS as the first middleware
+    config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins *((Cortex.config.cors.allowed_origins || '').split(',') +
+        origins *((Cortex.config.cors.allowed_origins || '*').split(',') +
                   [Cortex.config.cors.allowed_origins_regex || ''])
         resource '*',
                  :headers => :any,


### PR DESCRIPTION
- Default `Access-Control-Allow-Origin` to `*`
- Ensure `Rack::Cors` is always loaded first

I plan on allowing CORS on all routes in Production after this upcoming deployment. I don't believe this poses any serious risks to us, and we would be following the example of Github/Twitter/etc.
