### PR TITLE
Migrate to bower-rails

### DIFF
--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -1,0 +1,18 @@
+default: &default
+  first_thing:
+    - snippet: cloud66/node
+      target: any
+      execute: true
+    - command: npm install -g bower
+      sudo: true
+      target: any
+      execute: true
+
+development:
+  <<: *default
+
+staging:
+  <<: *default
+
+production:
+  <<: *default

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 ruby '2.2.2'
 
-# Server
-gem 'unicorn-rails', '~> 2.2.0'
-
 # Rails
 gem 'rails', '~> 4.2'
 
@@ -31,33 +28,12 @@ gem 'sprockets', '~> 2.12.3'
 gem 'ng-rails-csrf', '~> 0.1.0'
 gem 'angular-rails-templates', '~> 0.2.0'
 gem 'gon', '~> 5.2.3'
-gem 'jquery-rails', '~> 4.0.3'
-gem 'momentjs-rails', '~> 2.10.2'
 gem 'ngmin-rails', '~> 0.4.0'
 gem 'turbolinks', '~> 2.5.3'
 gem 'uglifier', '~> 2.7.1'
-gem 'underscore-rails', '~> 1.8.2'
 
-# Mail
-gem 'mailgun_rails'
-
-source 'https://rails-assets.org' do
-  gem 'rails-assets-angular', '~> 1.2'
-  gem 'rails-assets-angular-animate', '~> 1.2'
-  gem 'rails-assets-angular-resource', '~> 1.2'
-  gem 'rails-assets-angular-cookies', '~> 1.2'
-  gem 'rails-assets-angular-ui-router', '~> 0.2'
-  gem 'rails-assets-angular-bootstrap', '~> 0.12'
-  gem 'rails-assets-angular-flash', '~> 0.1.14'
-  gem 'rails-assets-angular-bootstrap-datetimepicker', '~> 0.3.8'
-  gem 'rails-assets-angular-redactor', '~> 1.1.4'
-  gem 'rails-assets-ng-file-upload', '~> 3.2.4'
-  gem 'rails-assets-ng-table', '~> 0.5.4'
-  gem 'rails-assets-bootstrap-sass-official', '~> 3.3.4'
-  gem 'rails-assets-ng-tags-input', '~> 2.3.0'
-  gem 'rails-assets-angular-bootstrap-switch', '~> 0.3'
-  gem 'rails-assets-angular-validation-match', '< 1.4'
-end
+# Dependency Management
+gem "bower-rails", "~> 0.10.0"
 
 # ActiveRecord
 gem 'rails-observers', '~> 0.1.2'
@@ -119,13 +95,6 @@ group :test, :development do
   gem 'jasmine-rails', '~> 0.10.7'
   gem 'guard-jasmine', '~> 2.0.6'
   gem 'jasmine-core', '~> 2.3'
-
-  source 'https://rails-assets.org' do
-    gem 'rails-assets-angular-mocks', '~> 1.2'
-    gem 'rails-assets-sinonjs', '~> 1.12.2'
-    gem 'rails-assets-sinon-ng', '~> 0.1.2'
-    gem 'rails-assets-angular-debaser', '~> 0.3.3'
-  end
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     CFPropertyList (2.3.1)
     actionmailer (4.2.1)
@@ -79,6 +78,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bower-rails (0.10.0)
     builder (3.2.2)
     byebug (6.0.2)
     celluloid (0.16.0)
@@ -116,8 +116,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
     doorkeeper (1.4.2)
       railties (>= 3.1)
     dotenv (2.0.1)
@@ -306,8 +304,6 @@ GEM
     hashr (0.0.22)
     hike (1.2.3)
     hitimes (1.2.2)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     httpclient (2.6.0.1)
     i18n (0.7.0)
     ice_nine (0.11.1)
@@ -338,10 +334,6 @@ GEM
       sprockets-rails
     jmespath (1.0.2)
       multi_json (~> 1.0)
-    jquery-rails (4.0.3)
-      rails-dom-testing (~> 1.0)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (1.8.2)
     json_spec (1.1.4)
       multi_json (~> 1.0)
@@ -349,7 +341,6 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (2.10.0)
@@ -361,10 +352,6 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailgun_rails (0.7.0)
-      actionmailer (>= 3.2.13)
-      json (>= 1.7.7)
-      rest-client (>= 1.6.7)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.5)
@@ -373,8 +360,6 @@ GEM
     minitest (5.6.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    momentjs-rails (2.10.2)
-      railties (>= 3.1)
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -382,7 +367,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    netrc (0.10.3)
     newrelic_rpm (3.12.1.298)
     ng-rails-csrf (0.1.0)
     ngmin-rails (0.4.0)
@@ -434,55 +418,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.1)
       sprockets-rails
-    rails-assets-angular (1.3.15)
-    rails-assets-angular-animate (1.3.15)
-      rails-assets-angular (= 1.3.15)
-    rails-assets-angular-bootstrap (0.13.0)
-      rails-assets-angular (>= 1.3.0)
-    rails-assets-angular-bootstrap-datetimepicker (0.3.12)
-      rails-assets-angular (~> 1.3.14)
-      rails-assets-moment (>= 2.9.0, < 3)
-    rails-assets-angular-bootstrap-switch (0.4.0)
-      rails-assets-angular (~> 1.3.15)
-      rails-assets-bootstrap (>= 2.3.2)
-      rails-assets-bootstrap-switch (= 3.3.2)
-      rails-assets-jquery (>= 1.9.0)
-    rails-assets-angular-cookies (1.3.15)
-      rails-assets-angular (= 1.3.15)
-    rails-assets-angular-debaser (0.3.3)
-      rails-assets-angular
-      rails-assets-angular-mocks
-    rails-assets-angular-flash (0.1.14)
-      rails-assets-angular (>= 1.0, < 1.4)
-    rails-assets-angular-mocks (1.3.15)
-      rails-assets-angular (= 1.3.15)
-    rails-assets-angular-redactor (1.1.4)
-      rails-assets-angular (>= 1.2.0)
-      rails-assets-jquery (>= 2.0.0)
-    rails-assets-angular-resource (1.3.15)
-      rails-assets-angular (= 1.3.15)
-    rails-assets-angular-ui-router (0.2.14)
-      rails-assets-angular (>= 1.0.8)
-    rails-assets-angular-validation-match (1.3.0)
-      rails-assets-angular (>= 1.2.0, < 2.0.0)
-    rails-assets-bootstrap (3.3.4)
-      rails-assets-jquery (>= 1.9.1)
-    rails-assets-bootstrap-sass-official (3.3.4)
-      rails-assets-jquery (>= 1.9.0)
-    rails-assets-bootstrap-switch (3.3.2)
-      rails-assets-bootstrap (>= 2.3.2)
-      rails-assets-jquery (>= 1.9.0)
-    rails-assets-jquery (2.1.4)
-    rails-assets-moment (2.10.3)
-    rails-assets-ng-file-upload (3.2.4)
-    rails-assets-ng-table (0.5.4)
-      rails-assets-angular (~> 1)
-    rails-assets-ng-tags-input (2.3.0)
-      rails-assets-angular (>= 1.2.1)
-    rails-assets-sinon-ng (0.1.2)
-      rails-assets-angular
-      rails-assets-sinonjs
-    rails-assets-sinonjs (1.12.2)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -498,7 +433,6 @@ GEM
       activesupport (= 4.2.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.15.0)
     rake (10.4.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
@@ -525,10 +459,6 @@ GEM
     request_store (1.1.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -604,17 +534,6 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    underscore-rails (1.8.2)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
-    unicorn (4.9.0)
-      kgio (~> 2.6)
-      rack
-      raindrops (~> 0.7)
-    unicorn-rails (2.2.0)
-      rack
-      unicorn
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -634,6 +553,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.10)
   better_errors (~> 2.1.1)
   binding_of_caller (~> 0.7.2)
+  bower-rails (~> 0.10.0)
   byebug
   codeclimate-test-reporter (~> 0.4.7)
   coffee-rails (~> 4.1.0)
@@ -663,14 +583,11 @@ DEPENDENCIES
   interactor-rails (~> 2.0)
   jasmine-core (~> 2.3)
   jasmine-rails (~> 0.10.7)
-  jquery-rails (~> 4.0.3)
   json
   json_spec (~> 1.1.4)
   kaminari (~> 0.16.3)
-  mailgun_rails
   mime-types (~> 2.5.0)
   mocha (~> 1.1.0)
-  momentjs-rails (~> 2.10.2)
   newrelic_rpm (~> 3.12.1)
   ng-rails-csrf (~> 0.1.0)
   ngmin-rails (~> 0.4.0)
@@ -682,25 +599,6 @@ DEPENDENCIES
   rack-cors (~> 0.4.0)
   rack-oauth2 (~> 1.1.1)
   rails (~> 4.2)
-  rails-assets-angular (~> 1.2)!
-  rails-assets-angular-animate (~> 1.2)!
-  rails-assets-angular-bootstrap (~> 0.12)!
-  rails-assets-angular-bootstrap-datetimepicker (~> 0.3.8)!
-  rails-assets-angular-bootstrap-switch (~> 0.3)!
-  rails-assets-angular-cookies (~> 1.2)!
-  rails-assets-angular-debaser (~> 0.3.3)!
-  rails-assets-angular-flash (~> 0.1.14)!
-  rails-assets-angular-mocks (~> 1.2)!
-  rails-assets-angular-redactor (~> 1.1.4)!
-  rails-assets-angular-resource (~> 1.2)!
-  rails-assets-angular-ui-router (~> 0.2)!
-  rails-assets-angular-validation-match (< 1.4)!
-  rails-assets-bootstrap-sass-official (~> 3.3.4)!
-  rails-assets-ng-file-upload (~> 3.2.4)!
-  rails-assets-ng-table (~> 0.5.4)!
-  rails-assets-ng-tags-input (~> 2.3.0)!
-  rails-assets-sinon-ng (~> 0.1.2)!
-  rails-assets-sinonjs (~> 1.12.2)!
   rails-observers (~> 0.1.2)
   redis-rails (~> 4.0)
   rspec (~> 3.2)
@@ -717,8 +615,6 @@ DEPENDENCIES
   timecop (~> 0.7.3)
   turbolinks (~> 2.5.3)
   uglifier (~> 2.7.1)
-  underscore-rails (~> 1.8.2)
-  unicorn-rails (~> 2.2.0)
 
 BUNDLED WITH
    1.10.6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://magnum.travis-ci.com/cbdr/cortex.svg?token=sAtZ4frpstZnGHoeyxTz&branch=master)](https://magnum.travis-ci.com/cbdr/cortex)
 
-Cortex is an identity, content management and reporting platform built by [Talent Development][td-github]. Its purpose is to provide central infrastructure for next-generation applications; exposing a single point of management while enabling quicker build-out of new software.
+Cortex is an identity, content distribution/management and reporting platform built by [Content Enablement][cb-ce-github]. Its purpose is to provide central infrastructure for next-generation applications; exposing a single point of management while enabling quicker build-out of new software.
 
 ### Initial Setup
 
@@ -12,7 +12,6 @@ Copy the example .env file and modify
 $ cp .env.example .env
 ```
 
-
 ### Setup - OS X
 
 **Prerequisites:** Xcode, Ruby ([rvm](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv)), [Homebrew](http://brew.sh/)
@@ -20,6 +19,7 @@ $ cp .env.example .env
 1. Install all homebrew managed dependencies from the `Brewfile` via `$ brew install $(cat Brewfile|grep -v "#")`
 2. Start servers with `launchctl` or [lunchy](https://github.com/eddiezane/lunchy): `$ lunchy start elasticsearch`
 3. Install Bundler and dependencies `$ gem install bundler && bundle install`
+4. Install Bower and its dependencies `$ npm install -g bower && bundle exec rake bower:install:development`
 4. Copy .env.example to .env and edit it to update APP_PATH to current path
 5. Create databases by running `rake db:create:all`
 6. Run migrations `$ rake db:migrate`
@@ -36,4 +36,4 @@ Finally, start Cortex: `$ rails s`
 
 - [Advice and Resources](https://github.com/cbdr/advice-and-resources) - Redesigned Workbuzz/Advice & Resources platform
 
-[td-github]: https://github.com/cb-talent-development "Talent Development on GitHub"
+[cb-ce-github]: https://github.com/cb-talent-development "Content Enablement on GitHub"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,10 +1,8 @@
-// Maintained by Gemfile
-//= require moment
-//= require underscore
-//= require jquery
-//= require bootstrap-sass-official
-
 // Maintained by bower-rails
+//= require jquery
+//= require underscore
+//= require moment
+//= require bootstrap-sass-official
 //= require angular
 //= require angular-rails-templates
 //= require angular-resource

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,43 @@
+{
+  "name": "cortex",
+  "authors": [
+    "Content Enablement <ContentEnablementProductTeam@careerbuilder.com>"
+  ],
+  "description": "An identity, content distribution/management and reporting platform powered by Grape",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~> 2.1.4",
+    "underscore": "~> 1.8.3",
+    "momentjs": "~> 2.10.2",
+    "angular": "~> 1.2",
+    "angular-animate": "~> 1.2",
+    "angular-resource": "~> 1.2",
+    "angular-cookies": "~> 1.2",
+    "angular-ui-router": "~> 0.2",
+    "angular-bootstrap": "~> 0.12",
+    "angular-flash": "~> 0.1.14",
+    "angular-bootstrap-datetimepicker": "~> 0.3.8",
+    "angular-redactor": "~> 1.1.4",
+    "ng-file-upload": "~> 3.2.4",
+    "ng-table": "~> 0.5.4",
+    "bootstrap-sass-official": "~> 3.3.4",
+    "ng-tags-input": "~> 2.3.0",
+    "angular-bootstrap-switch": "~> 0.4",
+    "angular-validation-match": "< 1.4"
+  },
+  "devDependencies": {
+    "angular-mocks": "~> 1.2",
+    "sinonjs": "~> 1.12.2",
+    "sinon-ng": "~> 0.1.2",
+    "angular-debaser": "~> 0.3.2"
+  },
+  "resolutions": {
+    "angular": "1.2.28"
+  }
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Cortex
     config.active_record.observers = :media_observer, :post_observer, :tenant_observer, :user_observer, :youtube_observer
     config.active_job.queue_adapter = :sidekiq
     config.assets.image_optim = false
+    config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')
 
     ActsAsTaggableOn.remove_unused_tags = true
     ActsAsTaggableOn.force_lowercase = true

--- a/config/initializers/bower_rails.rb
+++ b/config/initializers/bower_rails.rb
@@ -1,0 +1,19 @@
+BowerRails.configure do |bower_rails|
+  # Tell bower-rails what path should be considered as root. Defaults to Dir.pwd
+  # bower_rails.root_path = Dir.pwd
+
+  # Invokes rake bower:install before precompilation. Defaults to false
+  bower_rails.install_before_precompile = true
+
+  # Invokes rake bower:resolve before precompilation. Defaults to false
+  # bower_rails.resolve_before_precompile = true
+
+  # Invokes rake bower:clean before precompilation. Defaults to false
+  # bower_rails.clean_before_precompile = true
+
+  # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
+  # bower_rails.use_bower_install_deployment = true
+  #
+  # Invokes rake bower:install and rake bower:install:deployment with -F (force) flag. Defaults to false
+  # bower_rails.force_install = true
+end


### PR DESCRIPTION
Migrate from rails-assets to bower-rails, remove all gem'd asset dependencies. This also updates the README and provides necessary C66 CI steps to install Bower and its dependencies.
