### PR TITLE
Simplify Related Posts

### DIFF
--- a/app/api/v1/resources/posts.rb
+++ b/app/api/v1/resources/posts.rb
@@ -59,11 +59,8 @@ module API
             not_found! unless post
             authorize! :view, post
 
-            @posts = post.related(current_tenant, true)
-            ids = @posts.results.map {|post| post._source.id}
-
-            @posts = Post.find(ids).sort_by{ |post| ids.index post.id }
-            Entities::Post.represent paginate(Kaminari.paginate_array(@posts))
+            @posts = ::GetRelatedPosts.call(post: post, params: declared(post_params, include_missing: false), tenant: current_tenant, published: true).posts
+            Entities::Post.represent set_paginate_headers(@posts)
           end
 
           desc 'Show a published post', { entity: Entities::Post, nickname: "showFeedPost" }

--- a/app/interactors/get_related_posts.rb
+++ b/app/interactors/get_related_posts.rb
@@ -1,0 +1,9 @@
+class GetRelatedPosts
+  include Interactor
+
+  def call
+    related = context.post.related(context.tenant, context.published)
+
+    context.posts = related.page(context.params.page).per(context.params.per_page).records
+  end
+end


### PR DESCRIPTION
Vastly simplify `MLT` query for Related Posts. Create `GetRelatedPosts` interactor, use efficient pagination on the ES Relation.
