### PR TITLE
Sprockets Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,11 @@ gem 'sidekiq-failures', '~> 0.4.5'
 gem 'sinatra', '~> 1.4.7', require: false
 
 # Pipeline
-gem 'sprockets-rails', '2.3.3', :require => 'sprockets/railtie'
-gem 'sprockets', '2.12.4'
+gem 'sprockets-rails', '3.0.4', :require => 'sprockets/railtie'
+gem 'sprockets', '3.5.2'
+gem 'angular-rails-templates', '~> 1.0.0'
+gem 'ngannotate-rails', git: 'git://github.com/kikonen/ngannotate-rails', branch: 'master' # sprockets-rails related fixes not present in v0.15.4.1
+gem 'uglifier', '~> 2.7.2'
 
 # Templating
 gem 'haml', '~> 4.0.7'
@@ -69,10 +72,7 @@ gem 'font-awesome-sass', '~> 4.5.0'
 
 # JS
 gem 'ng-rails-csrf', '~> 0.1.0'
-gem 'angular-rails-templates', '~> 0.2.0'
 gem 'gon', '~> 6.0.1'
-gem 'ngmin-rails', '~> 0.4.0'
-gem 'uglifier', '~> 2.7.2'
 
 group :tasks do
   # Parsing
@@ -84,10 +84,21 @@ group :test, :development do
   gem 'dotenv', '~> 2.1.0'
   gem 'byebug'
 
+  # Cache/Sidekiq
+  gem 'redis-namespace', '~> 1.5'
+
+  # Pretty
+  gem 'better_errors', '~> 2.1.1'
+  gem 'binding_of_caller', '~> 0.7.2' # Used by Better Errors
+  gem 'pry-rails', '~> 0.3'
+end
+
+group :test do
   # Rspec
   gem 'rspec', '~> 3.4'
   gem 'rspec-rails', '~> 3.4'
   gem 'json_spec', '~> 1.1.4'
+  gem 'rspec-sidekiq', '~> 2.2.0'
 
   # Guard
   gem 'guard-rspec', '~> 4.6.4'
@@ -96,33 +107,17 @@ group :test, :development do
   gem 'mocha', '~> 1.1.0', require: false
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'database_cleaner', '~> 1.5.1'
+  gem 'timecop', '~> 0.8.0'
+  gem 'email_spec'
 
   # Javascript
   gem 'jasmine-rails', '~> 0.12.2'
   gem 'guard-jasmine', '~> 2.0.6'
   gem 'jasmine-core', '~> 2.4'
 
-  # Cache/Sidekiq
-  gem 'redis-namespace', '~> 1.5'
-end
-
-group :development do
-  # Pretty
-  gem 'better_errors', '~> 2.1.1'
-  gem 'binding_of_caller', '~> 0.7.2' # Used by Better Errors
-  gem 'pry-rails', '~> 0.3'
-end
-
-group :test do
+  # Etc
   gem 'codeclimate-test-reporter', '~> 0.4.8', require: false
-  gem 'timecop', '~> 0.8.0'
-  gem 'rspec-sidekiq', '~> 2.2.0'
   gem 'elasticsearch-extensions', '~> 0.0.20'
-  gem 'email_spec'
-end
-
-group :assets do
-  gem 'coffee-rails', '~> 4.1.0'
 end
 
 group :test, :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/kikonen/ngannotate-rails
+  revision: d8b9589108995ff6c438788f13df8f05879f7184
+  branch: master
+  specs:
+    ngannotate-rails (1.2.1)
+      execjs
+      rails (>= 3.1)
+
+GIT
   remote: git://github.com/thoughtbot/paperclip
   revision: e60f00027704298455c039e111d96bcf46e12822
   branch: master
@@ -61,9 +70,9 @@ GEM
     acts-as-taggable-on (3.5.0)
       activerecord (>= 3.2, < 5)
     addressable (2.4.0)
-    angular-rails-templates (0.2.0)
-      railties (>= 3.1)
-      sprockets (~> 2)
+    angular-rails-templates (1.0.0)
+      railties (>= 4.2, < 6)
+      sprockets (~> 3.0)
       tilt
     ansi (1.5.0)
     arel (6.0.3)
@@ -101,13 +110,6 @@ GEM
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    coffee-rails (4.1.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.10.0)
     concurrent-ruby (1.0.1)
     connection_pool (2.2.0)
     cortex-exceptions (0.0.4)
@@ -326,7 +328,6 @@ GEM
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
     hashr (2.0.0)
-    hike (1.2.3)
     htmlentities (4.3.4)
     httpclient (2.7.1)
     i18n (0.7.0)
@@ -389,8 +390,6 @@ GEM
     nenv (0.3.0)
     newrelic_rpm (3.15.0.314)
     ng-rails-csrf (0.1.0)
-    ngmin-rails (0.4.0)
-      rails (>= 3.1)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
@@ -535,18 +534,16 @@ GEM
       tilt (>= 1.3, < 3)
     six (0.2.0)
     slop (3.6.0)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.2)
     timecop (0.8.0)
     trollop (2.1.2)
     tzinfo (1.2.2)
@@ -575,7 +572,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on (~> 3.5)
-  angular-rails-templates (~> 0.2.0)
+  angular-rails-templates (~> 1.0.0)
   awesome_nested_set (~> 3.0)
   aws-sdk (~> 2.2)
   bcrypt (~> 3.1.11)
@@ -584,7 +581,6 @@ DEPENDENCIES
   bower-rails (~> 0.10.0)
   byebug
   codeclimate-test-reporter (~> 0.4.8)
-  coffee-rails (~> 4.1.0)
   cortex-exceptions (~> 0.0.4)
   database_cleaner (~> 1.5.1)
   devise (~> 3.5.6)
@@ -618,7 +614,7 @@ DEPENDENCIES
   mocha (~> 1.1.0)
   newrelic_rpm (~> 3.15.0)
   ng-rails-csrf (~> 0.1.0)
-  ngmin-rails (~> 0.4.0)
+  ngannotate-rails!
   nokogiri
   paperclip!
   paperclip-optimizer (~> 2.0)
@@ -640,8 +636,8 @@ DEPENDENCIES
   sidekiq-failures (~> 0.4.5)
   sinatra (~> 1.4.7)
   six (~> 0.2.0)
-  sprockets (= 2.12.4)
-  sprockets-rails (= 2.3.3)
+  sprockets (= 3.5.2)
+  sprockets-rails (= 3.0.4)
   timecop (~> 0.8.0)
   uglifier (~> 2.7.2)
   unicorn-rails (~> 2.2.0)


### PR DESCRIPTION
Upgrade to sprockets 3.x by upgrading several gems or replacing deprecated gems
