### PR TITLE
Add implicit conversion into String

### DIFF
--- a/app/helpers/youtube_helper.rb
+++ b/app/helpers/youtube_helper.rb
@@ -11,7 +11,7 @@ module YoutubeHelper
     info[:authors]             = [info[:channel_title]]
     info[:duration]            = video.duration
     info[:description]         = video.description
-    info[:source_published_at] = DateTime.parse(video.published_at)
+    info[:source_published_at] = DateTime.parse(video.published_at.to_s)
 
     info
   end


### PR DESCRIPTION
Sets video.published_at to a string to stop it from erroring out when Date.parse tries to parse it
