### PR TITLE
Find by Protocol Agnostic URL

### DIFF
--- a/app/api/v1/resources/webpages.rb
+++ b/app/api/v1/resources/webpages.rb
@@ -26,7 +26,7 @@ module V1
         end
         get 'feed' do
           require_scope! 'view:webpages'
-          @webpage ||= Webpage.find_by_url(params[:url])
+          @webpage = ::GetWebpageFeed.call(params: declared(clean_params(params), include_missing: false), tenant: current_tenant).webpage
           not_found! unless @webpage
           authorize! :view, @webpage
           present @webpage, with: ::V1::Entities::Webpage

--- a/app/interactors/get_webpage_feed.rb
+++ b/app/interactors/get_webpage_feed.rb
@@ -1,0 +1,18 @@
+class GetWebpageFeed
+  include Interactor
+
+  def call
+    webpage = ::Webpage
+    webpage = webpage.find_by_tenant_id(context.tenant) if context.tenant
+    webpage = webpage.find_by_protocol_agnostic_url(protocol_agnostic_url(context.params.url))
+    context.webpage = webpage
+  end
+
+  private
+
+  def protocol_agnostic_url(url)
+    uri = Addressable::URI.parse(url)
+    path = uri.path == '/' ? uri.path : uri.path.chomp('/')
+    "://#{uri.authority}#{path}"
+  end
+end

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -2,6 +2,8 @@ class Webpage < ActiveRecord::Base
   include FindByTenant
   include SearchableWebpage
 
+  scope :find_by_protocol_agnostic_url, ->(suffix) { where('url LIKE :suffix', query: "%#{suffix}") }
+
   acts_as_paranoid
   acts_as_taggable_on :seo_keywords
 


### PR DESCRIPTION
Add `find_by_protocol_agnostic_url` scope to `Webpages`, abstract Webpage Feed logic to `GetWebpageFeed` interactor, implement retrieval of Webpage by protocol-agnostic URL suffix
