### PR TITLE
Fix find_by_protocol_agnostic_url

### DIFF
--- a/app/interactors/get_webpage_feed.rb
+++ b/app/interactors/get_webpage_feed.rb
@@ -4,7 +4,7 @@ class GetWebpageFeed
   def call
     webpage = ::Webpage
     webpage = webpage.find_by_tenant_id(context.tenant) if context.tenant
-    webpage = webpage.find_by_protocol_agnostic_url(protocol_agnostic_url(context.params.url))
+    webpage = webpage.find_by_protocol_agnostic_url(protocol_agnostic_url(context.params.url)).first
     context.webpage = webpage
   end
 

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -2,7 +2,7 @@ class Webpage < ActiveRecord::Base
   include FindByTenant
   include SearchableWebpage
 
-  scope :find_by_protocol_agnostic_url, ->(suffix) { where('url LIKE :suffix', query: "%#{suffix}") }
+  scope :find_by_protocol_agnostic_url, ->(suffix) { where('url LIKE :suffix', suffix: "%#{suffix}") }
 
   acts_as_paranoid
   acts_as_taggable_on :seo_keywords


### PR DESCRIPTION
Fix issues with `find_by_protocol_agnostic_url` and the Interactor not selecting the first result
