### PR TITLE
Implement initial breadcrumb structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,9 @@ gem 'jquery-rails', '~> 4.1.1'
 gem 'ng-rails-csrf', '~> 0.1.0'
 gem 'gon', '~> 6.0.1'
 
+# View Helpers
+gem 'breadcrumbs_on_rails', '~> 2.3.1'
+
 group :tasks do
   # Parsing
   gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bower-rails (0.10.0)
+    breadcrumbs_on_rails (2.3.1)
     builder (3.2.2)
     byebug (9.0.4)
     capybara (2.7.1)
@@ -662,6 +663,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bower-rails (~> 0.10.0)
+  breadcrumbs_on_rails (~> 2.3.1)
   byebug
   capybara
   codeclimate-test-reporter (~> 0.4.8)

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,4 +1,6 @@
 class DashboardsController < AdminController
+  add_breadcrumb 'Dashboard', :dashboards_path
+
   def index
   end
 end

--- a/app/controllers/medias_controller.rb
+++ b/app/controllers/medias_controller.rb
@@ -1,4 +1,10 @@
 class MediasController < AdminController
+  add_breadcrumb 'Media', :medias_path
+
   def index
+  end
+
+  def show
+    add_breadcrumb 'Name goes here', media_path
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def title
+    title = 'Cortex Administration'
+    title += " | #{render_breadcrumbs}" if render_breadcrumbs
+    title
+  end
+
   def extra_config
     Cortex.config.extra
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,8 @@
     %meta{content: 'IE=edge', 'http-equiv' => 'X-UA-Compatible'}
     %meta{charset: 'utf-8'}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0'}
-    %title Cortex Administration
+    %title
+      = title
     = favicon_link_tag 'favicon.ico'
     = stylesheet_link_tag :application
     = csrf_meta_tags

--- a/app/views/partials/_breadcrumb.html.haml
+++ b/app/views/partials/_breadcrumb.html.haml
@@ -1,1 +1,2 @@
-%span.mdl-layout-title Dashboard
+%span.mdl-layout-title
+  = render_breadcrumbs


### PR DESCRIPTION
It works! Breadcrumbs are present in the page header and the `title` tag.
