### PR TITLE
Fix and Refactor update_url Task

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,6 +1,6 @@
 module PaperclipExtensions
   module Attachment
-    def arbitrary_url_for(pattern, style_name = :default)
+    def arbitrary_url_for(pattern, style_name = :original)
       Paperclip::Interpolations.interpolate pattern, self, style_name
     end
   end

--- a/lib/tasks/cortex.rake
+++ b/lib/tasks/cortex.rake
@@ -209,35 +209,26 @@ namespace :cortex do
   end
 
   namespace :media do
-    desc 'Manage Cortex media'
-    task :update_url => :environment do
-      old_url = ENV['OLD_PATH']
-      unless old_url
-        puts 'OLD_PATH must be set'
+    desc 'Update existing Media assets on S3 with new URL structure. Specify new structure in model, then pass old_path with the previous structure, i.e.: ":class/:attachment/:style-:id.:extension"'
+    task :update_url, [:old_path] => :environment do |t, args|
+      s3 = Aws::S3::Client.new(region: ENV['S3_REGION'], access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+      unless args[:old_path]
+        puts '"old_path" argument must be set'
       end
 
       Media.find_each do |media|
         unless media.attachment_file_name.blank?
-          object_key = media.attachment.arbitrary_url_for old_url
-
-          s3 = Aws::S3::Client.new(region: ENV['S3_REGION'], access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+          object_key = media.attachment.arbitrary_url_for args[:old_path]
 
           begin
-            s3.get_object({ bucket:ENV['S3_BUCKET_NAME'], key: object_key }, target: media.attachment_file_name)
-
-            file = File.new media.attachment_file_name
-
+            image = s3.get_object({bucket: ENV['S3_BUCKET_NAME'], key: object_key})
             puts "Re-saving image attachment #{media.id} - #{media.attachment_file_name}"
-            image = file
             media.attachment = image
             media.save
-            # if there are multiple styles, you want to recreate them:
+            # if there are multiple styles (thumbnail, etc), recreate them:
             media.attachment.reprocess!
-
-            file.close
-            File.delete media.attachment_file_name
           rescue => ex
-            puts "An error of type #{ex.class} occurred, message is #{ex.message}"
+            puts "An error of type #{ex.class} occurred, message is: '#{ex.message}'"
           end
         end
       end


### PR DESCRIPTION
- Initialize S3 client outside out of iterator. Re-initializing was causing intermittent failures
- `arbitrary_url_for`'s default `style_name` should be `:original`, as `:default` is Paperclip's default `300x300` thumbnail
- Parameterize `update_url`, rather than using ENV variables
- Store `s3.get_object` stream in memory rather than targeting filesystem
