### PR TITLE
Devise 4 Parameter Sanitizer API Changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :tenant_id
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:tenant_id])
   end
 end


### PR DESCRIPTION
Utilize new Devise 4.x Parameter Sanitizer/Strong Parameters API, before deprecation in Devise 4.2
