### PR TITLE
COR-210: Select ContentType

### DIFF
--- a/app/views/content_types/index.html.haml
+++ b/app/views/content_types/index.html.haml
@@ -4,4 +4,4 @@
 %ul
   - @content_types.each do |content_type|
     %li
-      = link_to content_type.name, edit_content_type_path(content_type)
+      = link_to content_type.name, new_content_type_content_item_path(content_type.id)

--- a/app/views/partials/_navigation.html.haml
+++ b/app/views/partials/_navigation.html.haml
@@ -2,6 +2,9 @@
   = link_to dashboards_path, class: 'mdl-navigation__link' do
     %i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> dashboard
     Dashboard
+  = link_to content_types_path, class: 'mdl-navigation__link' do
+    %i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> build
+    Create Content
   = link_to medias_path, class: 'mdl-navigation__link' do
     %i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> collections
     Media
@@ -20,9 +23,6 @@
   = link_to dashboards_path, class: 'mdl-navigation__link' do
     %i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> dns
     Applications
-  = link_to content_types_path, class: 'mdl-navigation__link' do
-    %i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> collections
-    Content Types
   = cell(:content_type, collection: ContentType.all).(:nav)
   .mdl-layout-spacer
   = link_to dashboards_path, class: 'mdl-navigation__link' do


### PR DESCRIPTION
@toastercup @arelia @kurtedelbrock 

Adds a new link to the top of the sidebar that is a link to the ContentType index (with a unique icon). The index contains a list of all the ContentTypes like before, except now they route to their respective forms.

Here's a screenshot:

<img width="1280" alt="screen shot 2016-08-02 at 10 26 33 am" src="https://cloud.githubusercontent.com/assets/8419757/17334406/c3f231dc-589b-11e6-800e-77d33b57dce1.png">
