### PR TITLE
COR-233: Current Tenant Display in Sidebar

### DIFF
--- a/app/cells/tenant/current.haml
+++ b/app/cells/tenant/current.haml
@@ -1,3 +1,2 @@
-%i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}>
-  = icon
+%i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> palette
 = name

--- a/app/cells/tenant_cell.rb
+++ b/app/cells/tenant_cell.rb
@@ -1,6 +1,5 @@
 class TenantCell < Cell::ViewModel
   property :name
-  property :icon
 
   def current
     render

--- a/app/views/partials/_user_control.html.haml
+++ b/app/views/partials/_user_control.html.haml
@@ -11,4 +11,5 @@
         %li.mdl-menu__item
           = current_user.tenant.name
         %li.mdl-menu__item
+          %i.material-icons> power_settings_new
           = link_to 'Logout', destroy_user_session_path, method: :delete

--- a/db/migrate/20160808150800_add_icon_to_tenants.rb
+++ b/db/migrate/20160808150800_add_icon_to_tenants.rb
@@ -1,5 +1,0 @@
-class AddIconToTenants < ActiveRecord::Migration
-  def change
-    add_column :tenants, :icon, :string, default: "palette"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808150800) do
+ActiveRecord::Schema.define(version: 20160718155015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20160808150800) do
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "tenants", force: :cascade do |t|
-    t.string   "name",          limit: 50,                      null: false
+    t.string   "name",          limit: 50,  null: false
     t.string   "subdomain",     limit: 50
     t.integer  "parent_id"
     t.integer  "lft"
@@ -394,7 +394,6 @@ ActiveRecord::Schema.define(version: 20160808150800) do
     t.integer  "owner_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "icon",                      default: "palette"
   end
 
   add_index "tenants", ["parent_id"], name: "index_tenants_on_parent_id", using: :btree


### PR DESCRIPTION
@toastercup @kurtedelbrock @arelia 

Adds the current tenant to the sidebar based (loosely) on devmynd's mockups. Creates a new cell structure for the current tenant and adds an "icon" attribute to the Tenant model, which is a string and handles the icon representing that specific tenant (the default is palette because I thought it was neat)

Here's what it looks like:
<img width="242" alt="screen shot 2016-08-08 at 10 13 42 am" src="https://cloud.githubusercontent.com/assets/8419757/17484744/0528f3b6-5d51-11e6-8eda-691a54e936ee.png">
