### PR TITLE
Fix ES Indexes With Special Characters

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -31,7 +31,7 @@ class ContentItem < ActiveRecord::Base
   def index
     __elasticsearch__.client.index(
       {index: content_type.content_items_index_name,
-       type: self.class.name.underscore,
+       type: self.class.name.parameterize('_'),
        id: id,
        body: as_indexed_json}
     )

--- a/app/models/content_type.rb
+++ b/app/models/content_type.rb
@@ -20,7 +20,8 @@ class ContentType < ActiveRecord::Base
   end
 
   def content_items_index_name
-    "#{Rails.env}_content_type_#{name.underscore}_content_items"
+    content_type_name_sanitized = name.parameterize('_')
+    "#{Rails.env}_content_type_#{content_type_name_sanitized}_content_items"
   end
 
   def content_items_mappings


### PR DESCRIPTION
Parameterize + underscore `ContentType` name in generated ES index names so `ContentType` names like 'Advice & Resources' can be supported
