### PR TITLE
Allow Null Expiry in Posts Feed

### DIFF
--- a/app/models/concerns/searchable_post.rb
+++ b/app/models/concerns/searchable_post.rb
@@ -110,9 +110,10 @@ module SearchablePost
     end
 
     def published_filter(model, filter)
-      filter << model.term_search(:draft, false)
-      filter << model.range_search(:published_at, :lte, DateTime.now.to_s)
-      filter << model.range_search(:expired_at, :gte, DateTime.now.to_s)
+      # Bring in documents based on Draft status, Published date met, or either: Expired date not yet met, or Expired date null
+      filter << {bool: {should: [model.term_search(:draft, false)]}}
+      filter << {bool: {should: [model.range_search(:published_at, :lte, DateTime.now.to_s)]}}
+      filter << {bool: {should: [model.range_search(:expired_at, :gte, DateTime.now.to_s), {missing: { field: :expired_at }}]}}
     end
   end
 end


### PR DESCRIPTION
Allow null `expired_at` fields in feed by utilizing `should` occurrence type in a `filter` context
