### PR TITLE
ContentItem.new Fixes

### DIFF
--- a/app/cells/field_cell.rb
+++ b/app/cells/field_cell.rb
@@ -15,7 +15,7 @@ class FieldCell < Cell::ViewModel
   def render_label
     @options[:form].label :data, field.name
   end
-  
+
   def render_field_id
     @options[:form].hidden_field :field_id, value: field.id
   end

--- a/app/cells/wizard/field/show.haml
+++ b/app/cells/wizard/field/show.haml
@@ -1,5 +1,13 @@
-= context[:form].fields_for 'field_items', field do |field_item_form|
-  - if field.field_type == "text_field_type"
-    = cell('cortex/field_types/core/text/text', FieldItem.new(field: field), form: field_item_form, default_value: '').(:input)
-  - if field.field_type == "boolean_field_type"
-    = cell('cortex/field_types/core/boolean/boolean', FieldItem.new(field: field), form: field_item_form, default_value: false).(:checkbox)
+= context[:form].fields_for 'field_items', field_item do |field_item_form|
+  - if field_item.field.field_type == "text_field_type"
+    = cell('cortex/field_types/core/text/text', field_item, form: field_item_form, default_value: '').(:input)
+  - if field_item.field.field_type == "boolean_field_type"
+    = cell('cortex/field_types/core/boolean/boolean', field_item, form: field_item_form, default_value: false).(:checkbox)
+  - if field_item.field.field_type == "tree_field_type"
+    = cell('cortex/field_types/core/tree/tree', FieldItem.new(field: field), form: field_item_form, index: index).(:tree)
+  - if field_item.field.field_type == "date_time_field_type"
+    = cell('cortex/field_types/core/date_time/date_time', field_item, form: field_item_form, default_value: '').(:datepicker)
+  - if field_item.field.field_type == "tag_field_type"
+    = cell('cortex/field_types/core/tag/tag', field_item, form: field_item_form, default_value: []).(:tag_picker)
+  - if field_item.field.field_type == "user_field_type"
+    = cell('cortex/field_types/core/user/user', field_item, form: field_item_form, default_value: User.all.first.id, user_data: User.all).(:dropdown)

--- a/app/cells/wizard/field_cell.rb
+++ b/app/cells/wizard/field_cell.rb
@@ -10,6 +10,12 @@ module Wizard
 
     private
 
+    def field_item
+      context[:content_item].field_items.find do |field_item|
+        field_item.field_id = id
+      end
+    end
+
     def field
       ::Field.find_by_id(id)
     end


### PR DESCRIPTION
- Retrieve `field_item` during `field_for` generation from `new`'d `field_items` in `ContentItem` controller.
- Restore existing `FieldType` rendering for `new` form
