### PR TITLE
Fix Media Widget HTML Escaping

### DIFF
--- a/app/helpers/widget_parsers/media_helper.rb
+++ b/app/helpers/widget_parsers/media_helper.rb
@@ -4,9 +4,9 @@ module WidgetParsers
       body_document = document_for(body)
 
       widget_nodes_for(body_document).each do |widget_node|
-        widget_node.content = render_widget_content widget_node
+        widget_node.inner_html = render_widget_inner widget_node
       end
-
+      
       body_document.to_html
     end
 
@@ -18,7 +18,7 @@ module WidgetParsers
       document.css 'media'
     end
 
-    def self.render_widget_content(widget)
+    def self.render_widget_inner(widget)
       Nokogiri::HTML::Builder.new do |doc|
         element = {src: Media.find_by_id(widget['id']).url}
         if widget['scale']

--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -4,9 +4,9 @@ namespace :employer do
   namespace :blog do
     desc 'Seed Employer Blog ContentType and Fields'
     task seed: :environment do
-      puts "Creating EmployerBlog ContentType..."
+      puts "Creating Employer Blog ContentType..."
       blog = ContentType.new({
-        name: "EmployerBlog",
+        name: "Employer Blog",
         description: "Blog for Employer",
         creator_id: 1,
         contract_id: 1


### PR DESCRIPTION
- Fix Nokogiri escaping Media Widget HTML
- Rename `EmployerBlog` ContentType => `Employer Blog`
