### PR TITLE
AR-44: Slug Uniqueness Per-Tenant

### DIFF
--- a/app/models/post_types/article_post.rb
+++ b/app/models/post_types/article_post.rb
@@ -2,10 +2,9 @@ class ArticlePost < Post
   index_name     [Rails.env, 'posts'].join('_')
   document_type  'post'
 
-  validates :copyright_owner, :slug, presence: true, length: { minimum: 1, maximum: 255 }
+  validates :copyright_owner, presence: true, length: { minimum: 1, maximum: 255 }
   validates :short_description, presence: true, length: { minimum: 25, maximum: 255 }
   validates :tag_list, :seo_keyword_list, :seo_title, :seo_description, length: { maximum: 255 }
-  validates_uniqueness_of :slug
 
   # TODO: Figure out a way to get this properly abstracted
   enum display: [:large, :medium, :small]

--- a/app/models/post_types/video_post.rb
+++ b/app/models/post_types/video_post.rb
@@ -2,10 +2,9 @@ class VideoPost < Post
   index_name     [Rails.env, 'posts'].join('_')
   document_type  'post'
 
-  validates :copyright_owner, :slug, presence: true, length: { minimum: 1, maximum: 255 }
+  validates :copyright_owner, presence: true, length: { minimum: 1, maximum: 255 }
   validates :short_description, presence: true, length: { minimum: 25, maximum: 255 }
   validates :tag_list, :seo_keyword_list, :seo_title, :seo_description, length: { maximum: 255 }
-  validates_uniqueness_of :slug
 
   # TODO: Figure out a way to get this properly abstracted
   enum display: [:large, :medium, :small]

--- a/db/migrate/20160906210044_remove_uniqueness_from_post_slug_index.rb
+++ b/db/migrate/20160906210044_remove_uniqueness_from_post_slug_index.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenessFromPostSlugIndex < ActiveRecord::Migration
+  def change
+    remove_index :posts, :slug
+    add_index :posts, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830222305) do
+ActiveRecord::Schema.define(version: 20160906210044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -329,7 +329,7 @@ ActiveRecord::Schema.define(version: 20160830222305) do
   end
 
   add_index "posts", ["author_id"], name: "index_posts_on_author_id", using: :btree
-  add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true, using: :btree
+  add_index "posts", ["slug"], name: "index_posts_on_slug", using: :btree
   add_index "posts", ["type"], name: "index_posts_on_type", using: :btree
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree
 


### PR DESCRIPTION
- Re-implement legacy Post Slug uniqueness to be per-tenant
- `unique` constraint removed from `Post.slug`, because it does not support scoping uniqueness across joined attributes
- Cannot use ActiveRecord's `uniqueness` validation to scope by `self.user.tenant.id`, as it does not support accessing record attributes from within the `conditions` block, which is what allows for complex scoping for unique validators. i.e., this does not work:

``` ruby
validates :slug, uniqueness: { conditions: -> { joins(user: :tenant).where(users: { tenant_id: user.tenant.id }) }
```

..because the record's `user` is not accessible from within that context. You'd think AR might inject context if we asked for it (or allow us to pass it in) a la:

``` ruby
validates :slug, uniqueness: { conditions: -> (record){ joins(user: :tenant).where(users: { tenant_id: record.user.tenant.id }) }
```

..or..

``` ruby
validates :slug, uniqueness: { conditions: -> (user: user){ joins(user: :tenant).where(users: { tenant_id: user.tenant.id }) }
```

..but neither yield anything useful.

For this reason, I have chosed to use a custom validation. Case closed!
