### PR TITLE
Sane Paperclip Optimization

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -25,7 +25,6 @@ class Media < ActiveRecord::Base
 
   has_attached_file :attachment,
                     :styles => {
-                      :original => {geometry: '9999x9999>'},
                       :large => {geometry: '1800x1800>', format: :jpg},
                       :medium => {geometry: '800x800>', format: :jpg},
                       :default => {geometry: '300x300>', format: :jpg},
@@ -33,7 +32,7 @@ class Media < ActiveRecord::Base
                       :micro => {geometry: '50x50>', format: :jpg},
                       :ar_post => {geometry: '1140x', format: :jpg}
                     },
-                    :processors => [:thumbnail],
+                    :processors => [:thumbnail, :paperclip_optimizer],
                     :preserve_files => 'true',
                     # :path => ':class/:attachment/:style-:id.:extension'
                     :path => ':class/:attachment/careerbuilder-:style-:id.:extension',

--- a/config/initializers/paperclip_optimizer.rb
+++ b/config/initializers/paperclip_optimizer.rb
@@ -5,7 +5,7 @@ Paperclip::PaperclipOptimizer.default_options = {
   jpegoptim: {
     allow_lossy: true,
     strip: :all,
-    max_quality: 60
+    max_quality: 90
   },
   advpng: false,
   gifsicle: {


### PR DESCRIPTION
We will continue to optimize thumbnails (but not originals), and up the lossy compression of JPEGs to a sane (and generally recommended) 90% rather than 60%
