### PR TITLE
Adjust Positioning of Search Icon

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -40,3 +40,9 @@
   border-radius: 50%;
   margin-left: 20px;
 }
+
+// Overrides
+
+.mdl-textfield--expandable .mdl-button--icon {
+  top: initial;
+}


### PR DESCRIPTION
Reset `top` property of search icon so that it is vertically centered within the `header` area

@toastercup @ElliottAYoung 
