### PR TITLE
Full Width ContentItem Grid

### DIFF
--- a/app/cells/index/index.haml
+++ b/app/cells/index/index.haml
@@ -1,3 +1,3 @@
-%table{ class: 'mdl-data-table mdl-js-data-table' }
+%table{ class: 'mdl-data-table mdl-js-data-table', style: 'width: 100%;' }
   = cell('index', @index, data: data).(:table_headers)
   = cell('index', @index, { data: data, content_type: @options[:content_type] }).(:table_body)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   add_index "bulk_jobs", ["user_id"], name: "index_bulk_jobs_on_user_id", using: :btree
 
   create_table "categories", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.integer  "user_id",                null: false
+    t.string   "name"
+    t.integer  "user_id",    null: false
     t.integer  "parent_id"
     t.integer  "lft"
     t.integer  "rgt"
@@ -71,6 +71,12 @@ ActiveRecord::Schema.define(version: 20161012161230) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "categories", ["depth"], name: "index_categories_on_depth", using: :btree
+  add_index "categories", ["lft"], name: "index_categories_on_lft", using: :btree
+  add_index "categories", ["parent_id"], name: "index_categories_on_parent_id", using: :btree
+  add_index "categories", ["rgt"], name: "index_categories_on_rgt", using: :btree
+  add_index "categories", ["user_id"], name: "index_categories_on_user_id", using: :btree
 
   create_table "categories_posts", id: false, force: :cascade do |t|
     t.integer "post_id",     null: false
@@ -80,10 +86,10 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   create_table "content_items", force: :cascade do |t|
     t.integer  "creator_id"
     t.integer  "content_type_id"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.datetime "deleted_at"
-    t.integer  "last_updated_by_id"
+    t.boolean  "is_published",    default: false
     t.integer  "updated_by_id"
     t.string   "state"
     t.datetime "publish_date"
@@ -98,7 +104,6 @@ ActiveRecord::Schema.define(version: 20161012161230) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.datetime "deleted_at"
-    t.jsonb    "tag_data"
     t.integer  "contract_id"
     t.string   "icon",        default: "help", null: false
     t.boolean  "publishable", default: false
@@ -195,25 +200,26 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   add_index "localizations", ["user_id"], name: "index_localizations_on_user_id", using: :btree
 
   create_table "media", force: :cascade do |t|
-    t.string   "name",                    limit: 255
+    t.string   "name"
     t.integer  "user_id"
-    t.string   "attachment_file_name",    limit: 255
-    t.string   "attachment_content_type", limit: 255
+    t.string   "attachment_file_name"
+    t.string   "attachment_content_type"
     t.integer  "attachment_file_size"
     t.datetime "attachment_updated_at"
-    t.string   "dimensions",              limit: 255
+    t.string   "dimensions"
     t.text     "description"
-    t.string   "alt",                     limit: 255
+    t.string   "alt"
     t.boolean  "active"
     t.datetime "deactive_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "digest",                  limit: 255
+    t.string   "digest"
     t.datetime "deleted_at"
     t.hstore   "meta"
-    t.string   "type",                    limit: 255, default: "Media", null: false
+    t.string   "type",                    default: "Media", null: false
   end
 
+  add_index "media", ["name"], name: "index_media_on_name", using: :btree
   add_index "media", ["user_id"], name: "index_media_on_user_id", using: :btree
 
   create_table "media_posts", id: false, force: :cascade do |t|
@@ -222,14 +228,14 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
-    t.integer  "resource_owner_id",             null: false
-    t.integer  "application_id",                null: false
-    t.string   "token",             limit: 255, null: false
-    t.integer  "expires_in",                    null: false
-    t.text     "redirect_uri",                  null: false
-    t.datetime "created_at",                    null: false
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
     t.datetime "revoked_at"
-    t.string   "scopes",            limit: 255
+    t.string   "scopes"
   end
 
   add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
@@ -237,12 +243,12 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
     t.integer  "application_id"
-    t.string   "token",             limit: 255, null: false
-    t.string   "refresh_token",     limit: 255
+    t.string   "token",             null: false
+    t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",                    null: false
-    t.string   "scopes",            limit: 255
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
   end
 
   add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
@@ -250,23 +256,23 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",         limit: 255,              null: false
-    t.string   "uid",          limit: 255,              null: false
-    t.string   "secret",       limit: 255,              null: false
-    t.text     "redirect_uri",                          null: false
+    t.string   "name",                      null: false
+    t.string   "uid",                       null: false
+    t.string   "secret",                    null: false
+    t.text     "redirect_uri",              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "owner_id"
-    t.string   "owner_type",   limit: 255
-    t.string   "scopes",                   default: "", null: false
+    t.string   "owner_type"
+    t.string   "scopes",       default: "", null: false
   end
 
   add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
   add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "onet_occupations", force: :cascade do |t|
-    t.string   "soc",         limit: 255
-    t.string   "title",       limit: 255
+    t.string   "soc"
+    t.string   "title"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -286,45 +292,46 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.integer  "user_id",                                          null: false
-    t.string   "title",               limit: 255
+    t.integer  "user_id",                              null: false
+    t.string   "title"
     t.datetime "published_at"
     t.datetime "expired_at"
     t.datetime "deleted_at"
-    t.boolean  "draft",                           default: true,   null: false
-    t.integer  "comment_count",                   default: 0,      null: false
+    t.boolean  "draft",               default: true,   null: false
+    t.integer  "comment_count",       default: 0,      null: false
     t.text     "body"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "short_description",   limit: 255
-    t.integer  "job_phase",                                        null: false
-    t.integer  "display",                                          null: false
+    t.string   "short_description"
+    t.integer  "job_phase",                            null: false
+    t.integer  "display",                              null: false
     t.text     "notes"
-    t.string   "copyright_owner",     limit: 255
-    t.string   "seo_title",           limit: 255
-    t.string   "seo_description",     limit: 255
-    t.string   "seo_preview",         limit: 255
-    t.string   "custom_author",       limit: 255
-    t.string   "slug",                                             null: false
+    t.string   "copyright_owner"
+    t.string   "seo_title"
+    t.string   "seo_description"
+    t.string   "seo_preview"
+    t.string   "custom_author"
+    t.string   "slug",                                 null: false
     t.integer  "featured_media_id"
     t.integer  "primary_industry_id"
     t.integer  "primary_category_id"
     t.integer  "tile_media_id"
     t.hstore   "meta"
-    t.string   "type",                            default: "Post", null: false
+    t.string   "type",                default: "Post", null: false
     t.integer  "author_id"
-    t.boolean  "is_wysiwyg",                      default: true
-    t.boolean  "noindex",                         default: false
-    t.boolean  "nofollow",                        default: false
-    t.boolean  "nosnippet",                       default: false
-    t.boolean  "noodp",                           default: false
-    t.boolean  "noarchive",                       default: false
-    t.boolean  "noimageindex",                    default: false
+    t.boolean  "is_wysiwyg",          default: true
+    t.boolean  "noindex",             default: false
+    t.boolean  "nofollow",            default: false
+    t.boolean  "nosnippet",           default: false
+    t.boolean  "noodp",               default: false
+    t.boolean  "noarchive",           default: false
+    t.boolean  "noimageindex",        default: false
   end
 
   add_index "posts", ["author_id"], name: "index_posts_on_author_id", using: :btree
   add_index "posts", ["slug"], name: "index_posts_on_slug", using: :btree
   add_index "posts", ["type"], name: "index_posts_on_type", using: :btree
+  add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree
 
   create_table "role_permissions", force: :cascade do |t|
     t.integer  "role_id"
@@ -335,12 +342,13 @@ ActiveRecord::Schema.define(version: 20161012161230) do
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.integer  "resource_id"
     t.string   "resource_type"
-    t.string   "resource_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
+  add_index "roles", ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
 
   create_table "snippets", force: :cascade do |t|
@@ -357,9 +365,9 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
-    t.string   "taggable_type", limit: 255
+    t.string   "taggable_type"
     t.integer  "tagger_id"
-    t.string   "tagger_type",   limit: 255
+    t.string   "tagger_type"
     t.string   "context",       limit: 128
     t.datetime "created_at"
   end
@@ -368,9 +376,8 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name",           limit: 255
-    t.integer "taggings_count",             default: 0
-    t.integer "tenant_id",                  default: 1
+    t.string  "name"
+    t.integer "taggings_count", default: 0
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
@@ -386,8 +393,8 @@ ActiveRecord::Schema.define(version: 20161012161230) do
     t.string   "contact_email", limit: 200
     t.string   "contact_phone", limit: 20
     t.datetime "deleted_at"
-    t.string   "contract",      limit: 255
-    t.string   "did",           limit: 255
+    t.string   "contract"
+    t.string   "did"
     t.datetime "active_at"
     t.datetime "deactive_at"
     t.integer  "owner_id"
@@ -395,27 +402,29 @@ ActiveRecord::Schema.define(version: 20161012161230) do
     t.datetime "updated_at"
   end
 
+  add_index "tenants", ["did"], name: "index_tenants_on_did", using: :btree
+  add_index "tenants", ["owner_id"], name: "index_tenants_on_owner_id", using: :btree
   add_index "tenants", ["parent_id"], name: "index_tenants_on_parent_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "",      null: false
+    t.string   "email",                             default: "",      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "tenant_id",                                            null: false
-    t.string   "encrypted_password",     limit: 255, default: "",      null: false
-    t.string   "reset_password_token",   limit: 255
+    t.integer  "tenant_id",                                           null: false
+    t.string   "encrypted_password",                default: "",      null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,       null: false
+    t.integer  "sign_in_count",                     default: 0,       null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: 255
-    t.string   "last_sign_in_ip",        limit: 255
-    t.string   "firstname",              limit: 255,                   null: false
-    t.string   "lastname",               limit: 255
-    t.string   "locale",                 limit: 30,  default: "en_US", null: false
-    t.string   "timezone",               limit: 30,  default: "EST",   null: false
-    t.boolean  "admin",                              default: false,   null: false
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "firstname",                                           null: false
+    t.string   "lastname"
+    t.string   "locale",                 limit: 30, default: "en_US", null: false
+    t.string   "timezone",               limit: 30, default: "EST",   null: false
+    t.boolean  "admin",                             default: false,   null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -423,8 +432,10 @@ ActiveRecord::Schema.define(version: 20161012161230) do
   add_index "users", ["tenant_id"], name: "index_users_on_tenant_id", using: :btree
 
   create_table "users_roles", id: false, force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "role_id"
+    t.integer  "user_id"
+    t.integer  "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
@@ -448,7 +459,6 @@ ActiveRecord::Schema.define(version: 20161012161230) do
     t.boolean  "noodp",                  default: false
     t.boolean  "noarchive",              default: false
     t.boolean  "noimageindex",           default: false
-    t.text     "seo_keywords"
   end
 
   add_index "webpages", ["user_id"], name: "index_webpages_on_user_id", using: :btree

--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -315,6 +315,7 @@ namespace :employer do
         [
           {
             "name": "Author",
+            "grid_width": 2,
             "cells": [{
               "field": {
                 "method": "author_image"


### PR DESCRIPTION
I attempted to use MDL's grid system to make the table responsive, but it doesn't play nicely (at all) with HTML `table` elements - this would need to be broken into `div`s before we could really tinker with responsiveness. So, instead, all I've simply done is:
- Stretch `ContentItem` index grid to match the full width of the page
