### PR TITLE
Gravatars in ContentItem Index

### DIFF
--- a/app/cells/index/content_item/column.haml
+++ b/app/cells/index/content_item/column.haml
@@ -1,4 +1,4 @@
 - @options[:cells].each do |field_cell|
   %span{ class: display_classes(field_cell[:display]) }
     = render_table_data(field_cell[:field])
-    %br
+  %br

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -45,7 +45,7 @@ class ContentItem < ActiveRecord::Base
   # content_item.author.user_image)
 
   def author_image
-    "<img src='https://robohash.org/#{id}.png' height='100' width='100'/>".html_safe
+    "<img src='#{creator.gravatar}' height='50px' />".html_safe
   end
 
   def publish_state


### PR DESCRIPTION
- Render Creator Gravatars in `ContentItem` Index, until system is replaced with Decorator Cell Plugin system
- Fix `br` tags being within the `span` that contains dynamic classes
