### PR TITLE
COR-309: Implement GUIDs

### DIFF
--- a/app/models/content_type.rb
+++ b/app/models/content_type.rb
@@ -5,7 +5,7 @@ class ContentType < ActiveRecord::Base
   include Elasticsearch::Model::Callbacks
 
   acts_as_paranoid
-  validates :name, :creator, :contract_id, presence: true
+  validates :name, :creator, presence: true
   after_save :rebuild_content_items_index
 
   belongs_to :creator, class_name: "User"

--- a/db/migrate/20161017205729_apply_uuids_to_custom_content_tables.rb
+++ b/db/migrate/20161017205729_apply_uuids_to_custom_content_tables.rb
@@ -16,7 +16,7 @@ class ApplyUuidsToCustomContentTables < ActiveRecord::Migration
       t.datetime :created_at, null: false
       t.datetime :updated_at, null: false
       t.datetime :deleted_at
-      t.integer :contract_id
+      t.uuid :contract_id
       t.string :icon, default: 'help', null: false
       t.boolean :publishable, default: false
 
@@ -28,7 +28,7 @@ class ApplyUuidsToCustomContentTables < ActiveRecord::Migration
 
     create_table :fields, id: false do |t|
       t.uuid :id, primary_key: true, default: 'uuid_generate_v4()'
-      t.integer :content_type_id, null: false
+      t.uuid :content_type_id, null: false
       t.string :field_type, null: false
       t.integer :order
       t.boolean :required, default: false, null: false
@@ -47,8 +47,8 @@ class ApplyUuidsToCustomContentTables < ActiveRecord::Migration
 
     create_table :content_items, id: false do |t|
       t.uuid :id, primary_key: true, default: 'uuid_generate_v4()'
-      t.integer  :creator_id
-      t.integer  :content_type_id
+      t.uuid  :creator_id
+      t.uuid  :content_type_id
       t.datetime :created_at, null: false
       t.datetime :updated_at, null: false
       t.datetime :deleted_at
@@ -65,8 +65,8 @@ class ApplyUuidsToCustomContentTables < ActiveRecord::Migration
 
     create_table :field_items, id: false do |t|
       t.uuid :id, primary_key: true, default: 'uuid_generate_v4()'
-      t.integer  :field_id
-      t.integer  :content_item_id
+      t.uuid  :field_id
+      t.uuid  :content_item_id
       t.datetime :created_at, null: false
       t.datetime :updated_at, null: false
       t.datetime :deleted_at
@@ -101,8 +101,8 @@ class ApplyUuidsToCustomContentTables < ActiveRecord::Migration
 
     create_table :contentable_decorators, id: false do |t|
       t.uuid :id, primary_key: true, default: 'uuid_generate_v4()'
-      t.integer :decorator_id
-      t.integer :contentable_id
+      t.uuid :decorator_id
+      t.uuid :contentable_id
       t.string :contentable_type
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 20161017205729) do
 
   create_table "content_items", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.integer  "creator_id"
-    t.integer  "content_type_id"
+    t.uuid  "content_type_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.datetime "deleted_at"
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 20161017205729) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.datetime "deleted_at"
-    t.integer  "contract_id"
+    t.uuid  "contract_id"
     t.string   "icon",        default: "help", null: false
     t.boolean  "publishable", default: false
   end
@@ -108,8 +108,8 @@ ActiveRecord::Schema.define(version: 20161017205729) do
   add_index "content_types", ["id"], name: "index_content_types_on_id", using: :btree
 
   create_table "contentable_decorators", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.integer  "decorator_id"
-    t.integer  "contentable_id"
+    t.uuid  "decorator_id"
+    t.uuid  "contentable_id"
     t.string   "contentable_type"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
@@ -149,8 +149,8 @@ ActiveRecord::Schema.define(version: 20161017205729) do
   add_index "documents", ["user_id"], name: "index_documents_on_user_id", using: :btree
 
   create_table "field_items", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.integer  "field_id"
-    t.integer  "content_item_id"
+    t.uuid  "field_id"
+    t.uuid  "content_item_id"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.datetime "deleted_at"
@@ -168,7 +168,7 @@ ActiveRecord::Schema.define(version: 20161017205729) do
   end
 
   create_table "fields", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.integer  "content_type_id",                 null: false
+    t.uuid  "content_type_id",                 null: false
     t.string   "field_type",                      null: false
     t.integer  "order"
     t.boolean  "required",        default: false, null: false


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

Create a migration to drop then subsequently recreate all Custom Content Tables to replace the default id with a UUID as the new Primary Key. Additionally adds indexes to optimize queries with the new UUID id field on the CCT tables.
