### PR TITLE
Tenant Switcher Tweaks

### DIFF
--- a/app/cells/tenant/current.haml
+++ b/app/cells/tenant/current.haml
@@ -1,3 +1,2 @@
-%i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}>
-  device_hub
-= name
+%i.mdl-color-text--blue-grey-400.material-icons{:role => "presentation"}> device_hub
+= name.titleize


### PR DESCRIPTION
- Change tenant switcher icon to something more appropriate
- `titleize` tenant name in tenant switcher
