### PR TITLE
COR-224: Edit Existing Assets

### DIFF
--- a/app/models/field_item.rb
+++ b/app/models/field_item.rb
@@ -18,7 +18,7 @@ class FieldItem < ActiveRecord::Base
   def field_type_instance(data_hash = nil)
     field_type_class = FieldType.get_subtype_constant(field.field_type)
     # data_before_typecast will give us a non-mutilated hash with Objects intact, just in case validations get called first
-    @field_type_instance ||= field_type_class.new(metadata: field.metadata, validations: field.validations, data: data_hash || data_before_type_cast)
+    @field_type_instance ||= field_type_class.new(metadata: field.metadata, validations: field.validations, data: data_hash.merge({ existing_data: data }) || data_before_type_cast)
     @field_type_instance if @field_type_instance.save!
   end
 


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

Very simple PR, we now pass either the previously entered data for a field_item or an empty hash (if it's a new field_item) so that we can access it on the field_type level. We are currently using this to access the previous URL for file uploads so that we can consistently use the same upload URL and version it on update with S3
