### PR TITLE
FieldCell Circular Dependency

### DIFF
--- a/app/cells/wizard/field_cell.rb
+++ b/app/cells/wizard/field_cell.rb
@@ -1,5 +1,5 @@
 module Wizard
-  class FieldCell < FieldCell
+  class FieldCell < ::FieldCell
     property :id
     property :label
     property :input


### PR DESCRIPTION
Fix occasional circular dependency issues by ensuring inherited `FieldCell` is pulled from global scope
