### PR TITLE
Cache 'require' Statements via Bootscale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem 'angular-rails-templates', '~> 1.0.2'
 gem 'ngannotate-rails', '~> 1.2.2'
 gem 'uglifier', '~> 3.0.3'
 
+# Performance
+gem 'bootscale', require: false
+
 # View
 gem 'haml', '~> 4.1.0.beta'
 gem 'cells', git: 'git://github.com/samstickland/cells', branch: 'collection_fix' # remove explicit 'cells' dependency when collection_fix is merged in. See: https://github.com/apotonick/cells/pull/415

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootscale (0.5.2)
     bootstrap-tagsinput-rails (0.4.2.1)
       railties (>= 3.1)
     bourbon (5.0.0.beta.7)
@@ -703,6 +704,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.11)
   better_errors
   binding_of_caller
+  bootscale
   bootstrap-tagsinput-rails (~> 0.4.2)
   bourbon (~> 5.0.0.beta)
   bower-rails (~> 0.11.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,3 +2,6 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+# Cache requires
+require 'bootscale/setup'


### PR DESCRIPTION
From the Readme:
Speedup applications boot by caching file locations during require calls.
Speed gain depends on your number of gems. Under 100 gems you likely won't see the difference, but for bigger applications it can save 1 to 3 seconds of boot time per 100 used gems.