### PR TITLE
Rails Observers Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'rolify', '~> 5.1'
 gem 'pundit', '~> 1.1'
 
 # Data
-gem 'rails-observers', git: 'https://github.com/rails/rails-observers.git'
+gem 'rails-observers', git: 'https://github.com/triloch/rails-observers.git'
 gem 'awesome_nested_set', git: 'https://github.com/cortex-cms/awesome_nested_set.git'
 gem 'paperclip', '~> 5.1.0'
 gem 'paperclip-optimizer', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,13 +16,6 @@ GIT
       rails (>= 4)
 
 GIT
-  remote: https://github.com/rails/rails-observers.git
-  revision: 3fe157d6cbb5b5e767ded248009fc59443d63fa1
-  specs:
-    rails-observers (0.1.3.alpha)
-      activemodel (>= 4.0, < 5.1)
-
-GIT
   remote: https://github.com/samstickland/cells.git
   revision: e5634e25b472d41913030eb82463b015f429f2ca
   branch: collection_fix
@@ -39,6 +32,13 @@ GIT
     grape-kaminari (0.1.8)
       grape
       kaminari
+
+GIT
+  remote: https://github.com/triloch/rails-observers.git
+  revision: ea30390cb07b4a37dd2f9d03966c89c1372f9dbe
+  specs:
+    rails-observers (0.1.3.alpha)
+      activemodel (>= 4.0, < 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -465,7 +465,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)


### PR DESCRIPTION
Fixes Rails Observers/Hooks not being run in Rails 5. See:
* https://github.com/rails/rails-observers/issues/52 and
* https://github.com/rails/rails-observers/issues/45

This fork contains a fix so that Observers are initialized properly:
https://github.com/triloch/rails-observers