### PR TITLE
COR-524: Media Pop-up z-index fix

### DIFF
--- a/app/assets/stylesheets/components/dialog.scss
+++ b/app/assets/stylesheets/components/dialog.scss
@@ -10,6 +10,7 @@
   height: 100%;
   bottom: 0;
   background: rgba(0, 0, 0, 0.0980392);
+  z-index: 1000;
 }
 
 .mdl-dialog {


### PR DESCRIPTION
To fix the issue regarding MDL checkboxes overlaying the pop-up dialog I just added a `z-index:1000;` to the `.dialog-backdrop` class. 