### PR TITLE
COR-569: Non-Image Uploads Bug Fix

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,19 +1,19 @@
-//=  require jquery3
+//= require jquery3
 // require jquery.turbolinks # temporarily disabled
-//  require jquery_ujs
+//= require jquery_ujs
 //= require underscore
-//  require riot-compiler
+//= require riot-compiler
 //= require material
-//=  require jquery-ui/datepicker
-//=  require jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon
-//  require bootstrap-tagsinput
+//= require jquery-ui/datepicker
+//= require jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon
+//= require bootstrap-tagsinput
 //= require clipboard
 
 //= require cortex-field_types-core/application
 
-//= require forms
 //= require base
+//= require forms
 //= require media_popups
 //= require sidebar-toggle
 
-//= require turbolinks
+// require turbolinks # temporarily disabled

--- a/app/assets/javascripts/base.js
+++ b/app/assets/javascripts/base.js
@@ -1,11 +1,6 @@
 (function() {
   // See: http://stackoverflow.com/questions/32923179/material-design-lite-not-working-with-turbolinks
-
-    document.addEventListener("turbolinks:load", function() {
-        console.log('It works on each visit!');
-        componentHandler.upgradeDom();
-        window.setModals()
-        window.setDatePickers();
-    });
-
+  $(document).on('turbolinks:load', function() {
+    componentHandler.upgradeDom();
+  });
 })();

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -1,31 +1,24 @@
-window.setDatePickers =  (function(){
-    function modifyButton() {
-        var button = $(".new_publish_state_button");
-
-        button.val("schedule");
-        button.text("Schedule Post");
+$(function() {
+  // If we restore Turbolinks, all of this should be wrapped in turbolinks:load
+  $(".datepicker").datepicker({
+    dateFormat: "dd/mm/yy",
+    onSelect: function (date) {
+      if ($(".new_publish_state_button").length > 0) {
+        modifyButton();
+      }
     }
-     function setDatePopUp() {
-    // If we restore Turbolinks, all of this should be wrapped in turbolinks:load
-    var datePickers =  $(".datepicker")
-    if(!datePickers.length){
-       return
-    }
-    datePickers.datepicker({
-        dateFormat: "dd/mm/yy",
-        onSelect: function (date) {
-            if ($(".new_publish_state_button").length > 0) {
-                modifyButton();
-            }
-        }
-    });
+  });
 
-         datePickers.on("focusout", function (ev) {
-        if (this.val() === "") {
-            this.closest('div').addClass('is-dirty');
-        }
-    });
+  $(".datepicker").on("focusout", function(ev){
+    if ($(this).val() == "") {
+      $(this).closest('div').addClass('is-dirty');
+    }
+  });
+});
+
+function modifyButton() {
+  var button = $(".new_publish_state_button");
+
+  button.val("schedule");
+  button.text("Schedule Post");
 }
-return setDatePopUp
-})()
-

--- a/app/assets/javascripts/media_popups.js
+++ b/app/assets/javascripts/media_popups.js
@@ -39,6 +39,6 @@ window.setModals = function () {
   }, {})
   window.MODALS = modals
 }
-// window.onload = function(){
-//    window.setModals()
-// }
+window.onload = function(){
+   window.setModals()
+}

--- a/app/models/field_item.rb
+++ b/app/models/field_item.rb
@@ -17,13 +17,14 @@ class FieldItem < ApplicationRecord
 
   def field_type_instance_params(data_hash)
     # Carefully construct a params object so we don't trigger our fragile setters when a value is nil
-    params = {metadata: field.metadata.merge(asset_check(data_hash)), validations: field.validations }
+    params = {metadata: field.metadata.merge(asset_check(data_hash)), validations: field.validations}
     params[:data] = data_hash if data_hash
     params
   end
 
   def asset_check(data_hash)
-   data_hash["asset"] ? {existing_data: data, content_type:  data_hash["asset"].content_type} : {existing_data: data}
+    return {existing_data: data} unless data_hash["asset"]
+    {existing_data: data, content_type:  data_hash["asset"].content_type}
   end
 
   def field_type_instance(data_hash = nil)
@@ -46,7 +47,7 @@ class FieldItem < ApplicationRecord
   end
 
   def add_specific_errors
-    field_type_instance.errors.each do |k, v|
+    field_type_instance.errors.each do |_k, v|
       errors.add(field.name.to_sym, v)
     end
   end


### PR DESCRIPTION
Due to the way ruby initializes classes instance variables and internal state depend the order in which methods get called. So because of this I had to create a function that passes the `AssetFieldType` cell the `content_type` in order to configure the content items metadata correctly.

**Method Added:** is in [app/models/field_item.rb](https://github.com/cbdr/cortex/blob/80a48cc4b0c3af0747a5ca7f096304eedf1831e7/app/models/field_item.rb) to pass the assets `content_type` to work, which can be viewed in the method below:
```ruby
def asset_check(data_hash)
   data_hash["asset"] ? {existing_data: data, content_type:  data_hash["asset"].content_type} : {existing_data: data}
end
```

**Rest of the code can be viewed here** [cortex-plugins-core/pull/23](https://github.com/cortex-cms/cortex-plugins-core/pull/23)