### PR TITLE
COR-574: Make Nav Not Too Narrow on Wizard Pages

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -18,6 +18,9 @@ $sidebar-toggle-button-transition: transform 500ms linear;
   transition: $sidebar-collapse-transition;
   position: relative;
   overflow-x: hidden;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
 }
 
 .sidebar__header {


### PR DESCRIPTION
Set flex child properties on sidebar b/c wizard page was squeezing it out

Pushing it up for a quick [small](https://24ways.org/2016/my-first-18-months-as-a-dev/) [code review](https://24ways.org/2016/new-tricks-for-an-old-dog/) and b/c it should have gone up with the previous nav story #401 

Looked like this:

![image](https://cloud.githubusercontent.com/assets/2359538/21370895/c1aecbb4-c6d3-11e6-9b2d-b66da129fe12.png)
