### PR TITLE
COR-537: Slug Uniqueness Validation

### DIFF
--- a/app/models/field_item.rb
+++ b/app/models/field_item.rb
@@ -17,7 +17,7 @@ class FieldItem < ApplicationRecord
 
   def field_type_instance_params(data_hash)
     # Carefully construct a params object so we don't trigger our fragile setters when a value is nil
-    params = {metadata: field.metadata.merge({existing_data: data}), validations: field.validations}
+    params = {metadata: field.metadata.merge({existing_data: data}), field: field, validations: field.validations}
     params[:data] = data_hash if data_hash
     params
   end

--- a/app/models/field_type.rb
+++ b/app/models/field_type.rb
@@ -2,7 +2,7 @@ class FieldType < ApplicationRecord
   extend ActiveSupport::DescendantsTracker
   DEFAULT_MAPPINGS = [].freeze
 
-  attr_accessor :field_name
+  attr_accessor :field_name, :field
   attr_reader :data, :validations, :metadata
 
   def self.direct_descendant_names

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,14 +58,19 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   end
 
   create_table "categories", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.integer  "user_id",                null: false
+    t.string   "name"
+    t.integer  "user_id",    null: false
     t.integer  "parent_id"
     t.integer  "lft"
     t.integer  "rgt"
     t.integer  "depth"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["depth"], name: "index_categories_on_depth", using: :btree
+    t.index ["lft"], name: "index_categories_on_lft", using: :btree
+    t.index ["parent_id"], name: "index_categories_on_parent_id", using: :btree
+    t.index ["rgt"], name: "index_categories_on_rgt", using: :btree
+    t.index ["user_id"], name: "index_categories_on_user_id", using: :btree
   end
 
   create_table "categories_posts", id: false, force: :cascade do |t|
@@ -192,23 +197,24 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   end
 
   create_table "media", force: :cascade do |t|
-    t.string   "name",                    limit: 255
+    t.string   "name"
     t.integer  "user_id"
-    t.string   "attachment_file_name",    limit: 255
-    t.string   "attachment_content_type", limit: 255
+    t.string   "attachment_file_name"
+    t.string   "attachment_content_type"
     t.integer  "attachment_file_size"
     t.datetime "attachment_updated_at"
-    t.string   "dimensions",              limit: 255
+    t.string   "dimensions"
     t.text     "description"
-    t.string   "alt",                     limit: 255
+    t.string   "alt"
     t.boolean  "active"
     t.datetime "deactive_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "digest",                  limit: 255
+    t.string   "digest"
     t.datetime "deleted_at"
     t.hstore   "meta"
-    t.string   "type",                    limit: 255, default: "Media", null: false
+    t.string   "type",                    default: "Media", null: false
+    t.index ["name"], name: "index_media_on_name", using: :btree
     t.index ["user_id"], name: "index_media_on_user_id", using: :btree
   end
 
@@ -218,48 +224,48 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
-    t.integer  "resource_owner_id",             null: false
-    t.integer  "application_id",                null: false
-    t.string   "token",             limit: 255, null: false
-    t.integer  "expires_in",                    null: false
-    t.text     "redirect_uri",                  null: false
-    t.datetime "created_at",                    null: false
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
     t.datetime "revoked_at"
-    t.string   "scopes",            limit: 255
+    t.string   "scopes"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
     t.integer  "application_id"
-    t.string   "token",             limit: 255, null: false
-    t.string   "refresh_token",     limit: 255
+    t.string   "token",             null: false
+    t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",                    null: false
-    t.string   "scopes",            limit: 255
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
   end
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",         limit: 255,              null: false
-    t.string   "uid",          limit: 255,              null: false
-    t.string   "secret",       limit: 255,              null: false
-    t.text     "redirect_uri",                          null: false
+    t.string   "name",                      null: false
+    t.string   "uid",                       null: false
+    t.string   "secret",                    null: false
+    t.text     "redirect_uri",              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "owner_id"
-    t.string   "owner_type",   limit: 255
-    t.string   "scopes",                   default: "", null: false
+    t.string   "owner_type"
+    t.string   "scopes",       default: "", null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
   end
 
   create_table "onet_occupations", force: :cascade do |t|
-    t.string   "soc",         limit: 255
-    t.string   "title",       limit: 255
+    t.string   "soc"
+    t.string   "title"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -279,44 +285,45 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.integer  "user_id",                                          null: false
-    t.string   "title",               limit: 255
+    t.integer  "user_id",                              null: false
+    t.string   "title"
     t.datetime "published_at"
     t.datetime "expired_at"
     t.datetime "deleted_at"
-    t.boolean  "draft",                           default: true,   null: false
-    t.integer  "comment_count",                   default: 0,      null: false
+    t.boolean  "draft",               default: true,   null: false
+    t.integer  "comment_count",       default: 0,      null: false
     t.text     "body"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "short_description",   limit: 255
-    t.integer  "job_phase",                                        null: false
-    t.integer  "display",                                          null: false
+    t.string   "short_description"
+    t.integer  "job_phase",                            null: false
+    t.integer  "display",                              null: false
     t.text     "notes"
-    t.string   "copyright_owner",     limit: 255
-    t.string   "seo_title",           limit: 255
-    t.string   "seo_description",     limit: 255
-    t.string   "seo_preview",         limit: 255
-    t.string   "custom_author",       limit: 255
-    t.string   "slug",                                             null: false
+    t.string   "copyright_owner"
+    t.string   "seo_title"
+    t.string   "seo_description"
+    t.string   "seo_preview"
+    t.string   "custom_author"
+    t.string   "slug",                                 null: false
     t.integer  "featured_media_id"
     t.integer  "primary_industry_id"
     t.integer  "primary_category_id"
     t.integer  "tile_media_id"
     t.hstore   "meta"
-    t.string   "type",                            default: "Post", null: false
+    t.string   "type",                default: "Post", null: false
     t.integer  "author_id"
-    t.boolean  "is_wysiwyg",                      default: true
-    t.boolean  "noindex",                         default: false
-    t.boolean  "nofollow",                        default: false
-    t.boolean  "nosnippet",                       default: false
-    t.boolean  "noodp",                           default: false
-    t.boolean  "noarchive",                       default: false
-    t.boolean  "noimageindex",                    default: false
-    t.boolean  "is_sticky",                       default: false
+    t.boolean  "is_wysiwyg",          default: true
+    t.boolean  "noindex",             default: false
+    t.boolean  "nofollow",            default: false
+    t.boolean  "nosnippet",           default: false
+    t.boolean  "noodp",               default: false
+    t.boolean  "noarchive",           default: false
+    t.boolean  "noimageindex",        default: false
+    t.boolean  "is_sticky",           default: false
     t.index ["author_id"], name: "index_posts_on_author_id", using: :btree
     t.index ["slug"], name: "index_posts_on_slug", using: :btree
     t.index ["type"], name: "index_posts_on_type", using: :btree
+    t.index ["user_id"], name: "index_posts_on_user_id", using: :btree
   end
 
   create_table "role_permissions", force: :cascade do |t|
@@ -328,10 +335,11 @@ ActiveRecord::Schema.define(version: 20161228215134) do
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.integer  "resource_id"
     t.string   "resource_type"
-    t.string   "resource_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
     t.index ["name"], name: "index_roles_on_name", using: :btree
   end
 
@@ -348,9 +356,9 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
-    t.string   "taggable_type", limit: 255
+    t.string   "taggable_type"
     t.integer  "tagger_id"
-    t.string   "tagger_type",   limit: 255
+    t.string   "tagger_type"
     t.string   "context",       limit: 128
     t.datetime "created_at"
     t.index ["context"], name: "index_taggings_on_context", using: :btree
@@ -365,9 +373,8 @@ ActiveRecord::Schema.define(version: 20161228215134) do
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name",           limit: 255
-    t.integer "taggings_count",             default: 0
-    t.integer "tenant_id",                  default: 1
+    t.string  "name"
+    t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
@@ -382,43 +389,47 @@ ActiveRecord::Schema.define(version: 20161228215134) do
     t.string   "contact_email", limit: 200
     t.string   "contact_phone", limit: 20
     t.datetime "deleted_at"
-    t.string   "contract",      limit: 255
-    t.string   "did",           limit: 255
+    t.string   "contract"
+    t.string   "did"
     t.datetime "active_at"
     t.datetime "deactive_at"
     t.integer  "owner_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["did"], name: "index_tenants_on_did", using: :btree
+    t.index ["owner_id"], name: "index_tenants_on_owner_id", using: :btree
     t.index ["parent_id"], name: "index_tenants_on_parent_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "",      null: false
+    t.string   "email",                             default: "",      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "tenant_id",                                            null: false
-    t.string   "encrypted_password",     limit: 255, default: "",      null: false
-    t.string   "reset_password_token",   limit: 255
+    t.integer  "tenant_id",                                           null: false
+    t.string   "encrypted_password",                default: "",      null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,       null: false
+    t.integer  "sign_in_count",                     default: 0,       null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: 255
-    t.string   "last_sign_in_ip",        limit: 255
-    t.string   "firstname",              limit: 255,                   null: false
-    t.string   "lastname",               limit: 255
-    t.string   "locale",                 limit: 30,  default: "en_US", null: false
-    t.string   "timezone",               limit: 30,  default: "EST",   null: false
-    t.boolean  "admin",                              default: false,   null: false
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "firstname",                                           null: false
+    t.string   "lastname"
+    t.string   "locale",                 limit: 30, default: "en_US", null: false
+    t.string   "timezone",               limit: 30, default: "EST",   null: false
+    t.boolean  "admin",                             default: false,   null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
     t.index ["tenant_id"], name: "index_users_on_tenant_id", using: :btree
   end
 
   create_table "users_roles", id: false, force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "role_id"
+    t.integer  "user_id"
+    t.integer  "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
   end
 
@@ -441,7 +452,6 @@ ActiveRecord::Schema.define(version: 20161228215134) do
     t.boolean  "noodp",                  default: false
     t.boolean  "noarchive",              default: false
     t.boolean  "noimageindex",           default: false
-    t.text     "seo_keywords"
     t.string   "dynamic_yield_sku"
     t.string   "dynamic_yield_category"
     t.index ["user_id"], name: "index_webpages_on_user_id", using: :btree

--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -68,7 +68,7 @@ namespace :employer do
       blog.fields.new(name: 'Body', field_type: 'text_field_type', metadata: {wysiwyg: true, parse_widgets: true})
       blog.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true})
       blog.fields.new(name: 'Description', field_type: 'text_field_type', validations: {presence: true})
-      blog.fields.new(name: 'Slug', field_type: 'text_field_type', validations: {presence: true})
+      blog.fields.new(name: 'Slug', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
       blog.fields.new(name: 'Author', field_type: 'user_field_type', validations: {presence: true})
       blog.fields.new(name: 'Tags', field_type: 'tag_field_type')
       blog.fields.new(name: 'Publish Date', field_type: 'date_time_field_type')


### PR DESCRIPTION
**EDIT:**   changed `:field_info` to `:field`

I also removed the setting method and changed to: `attr_accessor :field_name, :field`

this also relates to [cortex-plugins-core PR #33](https://github.com/cortex-cms/cortex-plugins-core/pull/33) where I change validations to directly use the `Field` instance variable for validations.

**OLD EDIT:** I added a new `attr_reader` to **FieldType** `:field_info`

```ruby
attr_reader :data, :field_info, :validations, :metadata

def field_info=(field)
  @field_info = field
end
```

This allows for `field` data to be accessible in the sub field types for helpful for scoping and running validations. 

Also I added a `uniqueness: true` validation in the blog rake task:
```ruby
blog.fields.new(name: 'Slug', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
```
The validations are run on the FieldType Level in `TextFieldType` which is here: [COR-568: JSONB Accessor + Uniqueness Validation #26](https://github.com/cortex-cms/cortex-plugins-core/pull/26)