### PR TITLE
COR-569: Paperclip Non-Image Upload Bug Fix

### DIFF
--- a/app/assets/javascripts/media_popups.js
+++ b/app/assets/javascripts/media_popups.js
@@ -50,9 +50,8 @@ $(".popup--open").on("click", function(ev){
 
 $(".media-select").on("click", function(ev){
   ev.preventDefault();
-  
+
   var id = $(this).data().id;
   var title = $(this).data().title;
-
   media_select_defer.resolve({'id': id, 'title': title})
 })

--- a/app/models/field_item.rb
+++ b/app/models/field_item.rb
@@ -17,7 +17,7 @@ class FieldItem < ApplicationRecord
 
   def field_type_instance_params(data_hash)
     # Carefully construct a params object so we don't trigger our fragile setters when a value is nil
-    params = {metadata: field.metadata.merge(modify_params(data_hash)), validations: field.validations}
+    params = {metadata: field.metadata.merge({existing_data: data, field_data: data_hash}), field_info: field, validations: field.validations}
     params[:data] = data_hash if data_hash
     params
   end
@@ -31,11 +31,6 @@ class FieldItem < ApplicationRecord
 
   def field_is_present
     field.present?
-  end
-
-  def modify_params(data_hash)
-    return {existing_data: data} unless data_hash["asset"]
-    {existing_data: data, content_type:  data_hash["asset"].content_type}
   end
 
   def field_item_content_is_valid

--- a/app/models/field_type.rb
+++ b/app/models/field_type.rb
@@ -3,7 +3,7 @@ class FieldType < ApplicationRecord
   DEFAULT_MAPPINGS = [].freeze
 
   attr_accessor :field_name
-  attr_reader :data, :validations, :metadata
+  attr_reader :data, :field_info, :validations, :metadata
 
   def self.direct_descendant_names
     direct_descendants.map{ |descendant| descendant.name.underscore }
@@ -15,6 +15,10 @@ class FieldType < ApplicationRecord
 
   def validations=(validations_hash)
     @validations = validations_hash.deep_symbolize_keys if validations_hash
+  end
+
+  def field_info=(field)
+    @field_info = field
   end
 
   def metadata=(metadata_hash)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -334,8 +334,8 @@ ActiveRecord::Schema.define(version: 20161221220406) do
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"
-    t.string   "resource_type"
     t.integer  "resource_id"
+    t.string   "resource_type"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
@@ -354,10 +354,10 @@ ActiveRecord::Schema.define(version: 20161221220406) do
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
-    t.string   "taggable_type"
     t.integer  "taggable_id"
-    t.string   "tagger_type"
+    t.string   "taggable_type"
     t.integer  "tagger_id"
+    t.string   "tagger_type"
     t.string   "context",       limit: 128
     t.datetime "created_at"
     t.index ["context"], name: "index_taggings_on_context", using: :btree


### PR DESCRIPTION
 Asset `content_type` is needed in order to fix the non-image uploads seen here: [COR-569: Support For Non-Image View Rendering && Paperclip Non-Image Upload bug fix #30](https://github.com/cortex-cms/cortex-plugins-core/pull/30). So in this PR I created a method in `FieldItem`  **modify_params**:

```ruby
def modify_params(data_hash)
  return {existing_data: data} unless data_hash["asset"]
  {existing_data: data, content_type:  data_hash["asset"].content_type}
end
```

This passes content_type to be accessible in `AssetFieldType`