### PR TITLE
CKEditor insertMedia Plugin Rewrite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rails', '~> 5.0.1'
 
 # Cortex-specific
 gem 'cortex-exceptions', '= 0.0.4'
-gem 'cortex-plugins-core', '= 0.7.2'
+gem 'cortex-plugins-core', '= 0.8.0'
 
 # API
 gem 'grape', '~> 0.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,17 @@ GIT
     rails-observers (0.1.3.alpha)
       activemodel (>= 4.0, < 5.1)
 
+PATH
+  remote: ../cortex-plugins-core
+  specs:
+    cortex-plugins-core (0.7.2)
+      cells (~> 4.1)
+      cells-haml (~> 0.0.10)
+      cells-rails (~> 0.0.6)
+      jsonb_accessor (~> 1.0.0.beta)
+      mimemagic (~> 0.3.2)
+      rails (>= 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,13 +147,6 @@ GEM
     concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
     cortex-exceptions (0.0.4)
-    cortex-plugins-core (0.7.2)
-      cells (~> 4.1)
-      cells-haml (~> 0.0.10)
-      cells-rails (~> 0.0.6)
-      jsonb_accessor (~> 1.0.0.beta)
-      mimemagic (~> 0.3.2)
-      rails (>= 4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
@@ -702,7 +706,7 @@ DEPENDENCIES
   cells-rails (~> 0.0.6)
   codeclimate-test-reporter (~> 0.6)
   cortex-exceptions (= 0.0.4)
-  cortex-plugins-core (= 0.7.2)
+  cortex-plugins-core!
   database_cleaner (~> 1.5)
   devise (~> 4.2.0)
   doorkeeper (~> 4.2)

--- a/app/assets/javascripts/media_popups.js
+++ b/app/assets/javascripts/media_popups.js
@@ -14,15 +14,15 @@ if (!window.DOM_HELPER) {
 }
 
 window.setModals = function () {
-  var modals = window.DOM_HELPER.getAll('.dialog-backdrop').reduce(function(modalHolder, modal, i) {
+  var modals = window.DOM_HELPER.getAll('.dialog-backdrop').reduce(function (modalHolder, modal, i) {
     modalHolder[modal.dataset.type] = {
       elem: modal,
       isOpen: false,
-      open: function() {
+      open: function () {
         modal.classList.remove('hidden');
         this.isOpen = true;
       },
-      close: function() {
+      close: function () {
         if (!this.isOpen) {
           return
         }
@@ -31,7 +31,7 @@ window.setModals = function () {
       }
     };
 
-    modal.querySelector('.close').onclick = function() {
+    modal.querySelector('.close').onclick = function () {
       modalHolder[modal.dataset.type].close();
     };
     return modalHolder
@@ -40,20 +40,23 @@ window.setModals = function () {
   window.MODALS = modals
 };
 
-window.onload = function() {
-   window.setModals();
+window.onload = function () {
+  window.setModals();
 };
 
-$(".popup--open").on("click", function(ev){
+$(".popup--open").on("click", function (ev) {
   ev.preventDefault();
   window.MODALS.featured.open();
 });
 
-$(".media-select--wysiwyg").on("click", function(ev){
+$(".media-select--wysiwyg").on("click", function (ev) {
   ev.preventDefault();
 
-  var id = $(this).data().id;
-  var title = $(this).data().title;
+  var element = $(this),
+    id = element.data().id,
+    title = element.data().title,
+    src = element.data().src,
+    alt = element.data().alt;
 
-  media_select_defer.resolve({'id': id, 'title': title});
+  media_select_defer.resolve({id: id, title: title, src: src, alt: alt});
 });

--- a/app/cells/index/table_body.haml
+++ b/app/cells/index/table_body.haml
@@ -6,7 +6,7 @@
           = cell('index/content_item', nil, { cells: column[:cells], content_item: content_item }).(:column)
       - if context[:popup]
         %td{ class: 'mdl-data-table__cell--non-numeric' }
-          %a{ href: "#", data: { id: content_item.id, title: content_item_title(content_item), thumb: content_item_thumb_url(content_item) }, class: "media-select--#{context[:popup]} mdl-button mdl-js-button mdl-button--icon" }
+          %a{ href: "#", data: { id: content_item.id, title: content_item_title(content_item), thumb: content_item_thumb_url(content_item), src: content_item_asset_url(content_item), alt: content_item_asset_alt_text(content_item) }, class: "media-select--#{context[:popup]} mdl-button mdl-js-button mdl-button--icon" }
             %i{ class: 'material-icons' }
               add
       - else

--- a/app/cells/index_cell.rb
+++ b/app/cells/index_cell.rb
@@ -26,4 +26,12 @@ class IndexCell < Cell::ViewModel
   def content_item_thumb_url(content_item)
     content_item.field_items.find { |field_item| field_item.field.name == 'Asset' }.data['asset']['style_urls']['mini']
   end
+
+  def content_item_asset_url(content_item)
+    content_item.field_items.find { |field_item| field_item.field.name == 'Asset' }.data['asset']['url']
+  end
+
+  def content_item_asset_alt_text(content_item)
+    content_item.field_items.find { |field_item| field_item.field.name == 'Alt Tag' }.data['text']
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,7 +17,7 @@
         %main.mdl-layout__content.layout__main-content
           = yield
 
-    %script{src: '//cdn.ckeditor.com/4.6.1/standard/ckeditor.js', type: 'text/javascript'}
+    %script{src: '//cdn.ckeditor.com/4.6.1/standard-all/ckeditor.js', type: 'text/javascript'}
     = javascript_include_tag :application, {'data-turbolinks-eval': false}
     = render 'layouts/google_analytics' if extra_config.google_analytics_id?
     = render 'partials/flash'


### PR DESCRIPTION
This PR, along with one in `cortex-plugins-core`, supports the rewrite of the `insertMedia` plugin to use the CKEditor Widget system. This way, the image is not directly editable by a user - they need to go through the widget system or edit the `<media>` tag to alter what's produced in the `<img`> tag. Additionally, upon insertion, images and their alt text are now pulled through and immediately displayed.

Please see the CKEditor Widget tutorial for more details on how all this zaniness works: http://docs.ckeditor.com/#!/guide/widget_sdk_tutorial_2