### PR TITLE
ContentItem Name In Breadcrumbs

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -24,8 +24,8 @@ class ContentItemsController < AdminController
 
     title = @content_item.field_items.find { |field_item| field_item.field.name == 'Title' }.data['text']
     add_breadcrumb content_type.name.pluralize, :content_type_content_items_path
-    add_breadcrumb 'Edit'
     add_breadcrumb title
+    add_breadcrumb 'Edit'
   end
 
   def update


### PR DESCRIPTION
Pulls `ContentItem` Title into Breadcrumbs for CRUD (temporarily hardcoded)