### PR TITLE
COR-625: Change Order of Research Tree Nodes - per Justin

### DIFF
--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -6,9 +6,9 @@ namespace :employer do
     task seed: :environment do
       def research_tree
         tree = Tree.new
+        tree.add_node({name: ""})
         tree.add_node({name: "CB Research"})
         tree.add_node({name: "Third Party Research"})
-        tree.add_node({name: "N/A"})
 
         tree
       end


### PR DESCRIPTION
Very simple - Clears the N/A out of the Tree Node value for the Research Dropdown tree and puts it as the first available option in the form's dropdown