### PR TITLE
Dialog Polyfill Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ gem 'jquery-turbolinks', '~> 2.1'
 gem 'jquery-ui-rails', '~> 6.0.1'
 gem 'ng-rails-csrf', '~> 0.1.0'
 gem 'bootstrap-tagsinput-rails', '~> 0.4.2'
+gem 'dialog-polyfill-rails', '~> 0.4.5'
 
 group :tasks do
   # Parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    dialog-polyfill-rails (0.4.5.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     doorkeeper (4.2.0)
@@ -707,6 +708,7 @@ DEPENDENCIES
   cortex-plugins-core (= 0.10.4)
   database_cleaner (~> 1.5)
   devise (~> 4.2.0)
+  dialog-polyfill-rails (~> 0.4.5)
   doorkeeper (~> 4.2)
   dotenv-rails
   elasticsearch-extensions (~> 0.0.23)
@@ -790,4 +792,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@
 @import 'jquery-ui/datepicker';
 @import "jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon";
 @import 'bootstrap-tagsinput.scss';
-@import 'dialog-polyfill/dialog-polyfill.css';
+@import 'dialog-polyfill';
 
 @import 'variables/colors';
 @import 'variables/typography';

--- a/bower.json
+++ b/bower.json
@@ -33,8 +33,7 @@
     "angular-validation-match": "< 1.4",
 
     "jqueryui-timepicker-addon": "~> 1.6",
-    "clipboard": "~> 1.5.16",
-    "dialog-polyfill": "~> 0.4.5"
+    "clipboard": "~> 1.5.16"
   },
   "devDependencies": {
     "angular-mocks": "~> 1.2",


### PR DESCRIPTION
* fix: dialog polyfill not working in precompiled environments
  * Replaces bower `dialog-polyfill` package with one optimized for the pipeline, `dialog-polyfill-rails`