### PR TITLE
Fix: Prev and Next Buttons on Datepicker

### DIFF
--- a/app/assets/stylesheets/components/ui.scss
+++ b/app/assets/stylesheets/components/ui.scss
@@ -106,6 +106,10 @@
   margin: 0;
 }
 
+.ui-datepicker .ui-icon {
+  text-indent: 0;
+}
+
 .ui-datepicker td[data-handler='selectDay']:hover {
   background-color: $color-teal-dark;
 


### PR DESCRIPTION
Quick fix to re-add prev and next buttons on datepicker. Remove `text-indent`

Before:

![image](https://cloud.githubusercontent.com/assets/2359538/22907063/f11c40e8-f20c-11e6-9f13-1378a5c15d2e.png)

After:

![image](https://cloud.githubusercontent.com/assets/2359538/22907056/e84c2140-f20c-11e6-9dac-8b566017eda0.png)
