### PR TITLE
FieldType Id Missing From Asset Path Url Patch

### DIFF
--- a/app/models/field_item.rb
+++ b/app/models/field_item.rb
@@ -26,6 +26,8 @@ class FieldItem < ApplicationRecord
     field_type_class = FieldType.get_subtype_constant(field.field_type)
     # data_before_typecast will give us a non-mutilated hash with Objects intact, just in case validations get called first
     @field_type_instance ||= field_type_class.new(field_type_instance_params(data_hash))
+    @field_type_instance.save
+    @field_type_instance
   end
 
   def field_is_present


### PR DESCRIPTION
In a previous story we removed `@field_type_instance.save!` from `field_type_instance` method so that validations would bubble up to the `ContentItem` to be re-rendered with all from errors. But we forgot to save the `FieldType` instance at all. 

**This resulted in a Field not having a id resulting in what you see below:**

**Valid Asset URL:** /asset_field_types/assets/careerbuilder-mini-7cd5c9ee-c7c2-4190-92b8-5f2b62d2082d.jpg?1485798415

**Invalid Asset URL:** /asset_field_types/assets/careerbuilder-mini-.jpg?1487866858