### PR TITLE
Initial Newsfeed Post Seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,17 +1,36 @@
 # Create root tenant and user
-tenant_seed   = SeedData.cortex_tenant
-user_seed     = tenant_seed.creator
+tenant_seed = SeedData.cortex_tenant
+user_seed = tenant_seed.creator
+initial_post_seed = SeedData.initial_post
 
-unless Tenant.find_by_name(tenant_seed.name)
+initial_post = Post.find_by_slug(initial_post_seed.slug) || ArticlePost.new(title: initial_post_seed.title,
+                                                                            body: initial_post_seed.body,
+                                                                            short_description: initial_post_seed.short_description,
+                                                                            slug: initial_post_seed.slug,
+                                                                            draft: false,
+                                                                            published_at: Time.now,
+                                                                            job_phase: initial_post_seed.job_phase,
+                                                                            display: initial_post_seed.display,
+                                                                            copyright_owner: initial_post_seed.copyright_owner)
+
+existing_tenant = Tenant.find_by_name(tenant_seed.name)
+
+if existing_tenant
+  initial_post.user = existing_tenant.owner
+else
   cortex_tenant = Tenant.new(name: tenant_seed.name)
 
-  cortex_tenant.owner   = User.new(email: user_seed.email,
-                           firstname: user_seed.firstname,
-                           lastname: user_seed.lastname,
-                           password: user_seed.password,
-                           password_confirmation: user_seed.password,
-                           tenant: cortex_tenant,
-                           admin: true)
+  cortex_tenant.owner = User.new(email: user_seed.email,
+                                 firstname: user_seed.firstname,
+                                 lastname: user_seed.lastname,
+                                 password: user_seed.password,
+                                 password_confirmation: user_seed.password,
+                                 tenant: cortex_tenant,
+                                 admin: true)
 
   cortex_tenant.save!
+
+  initial_post.user = cortex_tenant.owner
 end
+
+initial_post.save!

--- a/db/seeds.yml
+++ b/db/seeds.yml
@@ -1,4 +1,12 @@
 defaults: &defaults
+  initial_post:
+    title: 'Welcome to Cortex!'
+    slug: 'initial-news-post'
+    job_phase: 'Discovery'
+    display: 'medium'
+    short_description: 'This is an initial test news ArticlePost for Cortex that you can delete'
+    copyright_owner: 'Cortex CMS'
+    body: 'Your initial superadministrator user credentials are:<br /><br /><strong>Email:</strong>&nbsp;admin@cortexcms.org<br /><strong>Password:</strong>&nbsp;welcome1<br /><br />Please change them in deployed environments.'
   cortex_tenant:
     name: 'cortex'
     creator: {email: 'admin@cortexcms.org', firstname: 'Cortex', lastname: 'Admin', password: 'welcome1'}


### PR DESCRIPTION
**Purpose:**
Implement initial newsfeed `ArticlePost` for seeder, refactor seeder to be re-runnable. This also gives us an initial `Post` so that the `last_updated_at` scope executes without error on fresh databases.

**JIRA:**
N/A

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
 N/A

* After
N/A

**QA Links:**
N/A

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * Execute `bundle exec rake db:seed` and witness a new initial `Post` in your newsfeed

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies:**
N/A

**Additional Information**
N/A