### PR TITLE
EM-1049: Table Issues

### DIFF
--- a/app/api/v1/entities/webpage.rb
+++ b/app/api/v1/entities/webpage.rb
@@ -20,9 +20,13 @@ module V1
       expose :dynamic_yield_sku, documentation: { type: 'String', desc: "Dynamic Yield Webpage SKU/ID" }
       expose :dynamic_yield_category, documentation: { type: 'String', desc: "Dynamic Yield Webpage Category" }
 
+      expose :tables_widget_json, documentation:  {type: 'Hash', is_array: true, desc: 'Tables Widget Data as JSON'}
+
       with_options if: { full: true } do
         expose :user, with: '::V1::Entities::User', documentation: {type: 'User', desc: 'Owner'}
         expose :url, documentation: { type: 'String', desc: 'URL of Webpage' }
+
+        expose :tables_widget_yaml, documentation:  {type: 'Hash', is_array: true, desc: 'Tables Widget Data as YAML'}
       end
     end
   end

--- a/app/assets/legacy_templates/webpages/edit.html
+++ b/app/assets/legacy_templates/webpages/edit.html
@@ -29,7 +29,7 @@
           <div class="form-group">
             <label for="description">Description (155 characters max)</label>
             <textarea id="seo_description" name="seo_description" class="form-control"
-                   ng-model="data.webpage.seo_description" placeholder="Page Description" required></textarea>
+                      ng-model="data.webpage.seo_description" placeholder="Page Description" required></textarea>
           </div>
 
           <div class="keywords tags">
@@ -48,32 +48,38 @@
 
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="noindex" id="noindex" ng-model="data.webpage.noindex"> Don't Index This Page In Search Engines (<strong>noindex</strong>)
+              <input type="checkbox" name="noindex" id="noindex" ng-model="data.webpage.noindex"> Don't Index This Page
+              In Search Engines (<strong>noindex</strong>)
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="nofollow" id="nofollow" ng-model="data.webpage.nofollow"> Don't Index Any Pages This Page Links To (<strong>nofollow</strong>)
+              <input type="checkbox" name="nofollow" id="nofollow" ng-model="data.webpage.nofollow"> Don't Index Any
+              Pages This Page Links To (<strong>nofollow</strong>)
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="nosnippet" id="nosnippet" ng-model="data.webpage.nosnippet"> Don't Show A Snippet in Google Search Results (<strong>nosnippet</strong>)
+              <input type="checkbox" name="nosnippet" id="nosnippet" ng-model="data.webpage.nosnippet"> Don't Show A
+              Snippet in Google Search Results (<strong>nosnippet</strong>)
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="noodp" id="noodp" ng-model="data.webpage.noodp"> Don't Show Description from ODP/DMOZ (<strong>noodp</strong>)
+              <input type="checkbox" name="noodp" id="noodp" ng-model="data.webpage.noodp"> Don't Show Description from
+              ODP/DMOZ (<strong>noodp</strong>)
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="noarchive" id="noarchive" ng-model="data.webpage.noarchive"> Don't Show "Cached" Link on Google Search Results (<strong>noarchive</strong>)
+              <input type="checkbox" name="noarchive" id="noarchive" ng-model="data.webpage.noarchive"> Don't Show
+              "Cached" Link on Google Search Results (<strong>noarchive</strong>)
             </label>
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="noimageindex" id="noimageindex" ng-model="data.webpage.noimageindex"> Don't Show This Page As the Source For Images in Google Image Search (<strong>noimageindex</strong>)
+              <input type="checkbox" name="noimageindex" id="noimageindex" ng-model="data.webpage.noimageindex"> Don't
+              Show This Page As the Source For Images in Google Image Search (<strong>noimageindex</strong>)
             </label>
           </div>
         </form>
@@ -96,7 +102,21 @@
         </form>
       </div>
     </tab>
+    <tab>
+      <tab-heading><i class="fa fa-puzzle-piece"></i> Widgets</span></tab-heading>
+      <div>
+        <form novalidate name="webpageForm">
+          <div class="form-group">
+            <label for="tables_widget_yaml">Tables Data</label>
+            <textarea id="tables_widget_yaml" name="tables_widget_yaml" class="form-control" rows="15"
+                      ng-model="data.webpage.tables_widget_yaml"
+                      placeholder="YAML-formatted table data"></textarea>
+          </div>
+        </form>
+      </div>
+    </tab>
   </tabset>
 
-  <iframe class="webpage-frame" id="webpage-frame" ng-src="{{ data.webpage.url + '?editing_mode=1' | trustAsResourceUrl }}" disabled></iframe>
+  <iframe class="webpage-frame" id="webpage-frame"
+          ng-src="{{ data.webpage.url + '?editing_mode=1' | trustAsResourceUrl }}" disabled></iframe>
 </div>

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -2,6 +2,8 @@ class Webpage < ApplicationRecord
   include FindByTenant
   include SearchableWebpage
 
+  serialize :tables_widget
+
   scope :find_by_protocol_agnostic_url, ->(suffix) { where('url LIKE :suffix', suffix: "%#{suffix}") }
 
   acts_as_paranoid
@@ -12,4 +14,20 @@ class Webpage < ApplicationRecord
   has_many :documents, through: :snippets, :dependent => :destroy
 
   accepts_nested_attributes_for :snippets
+
+  def tables_widget_yaml
+    tables_widget.to_yaml
+  end
+
+  def tables_widget_yaml= p
+    self.tables_widget = YAML.load(p)
+  end
+
+  def tables_widget_json
+    tables_widget.to_json
+  end
+
+  def tables_widget_json= p
+    self.tables_widget = JSON.parse(p, quirks_mode: true) # Quirks mode will let us parse a null JSON object
+  end
 end

--- a/db/migrate/20170327182543_add_tables_widget_to_webpage.rb
+++ b/db/migrate/20170327182543_add_tables_widget_to_webpage.rb
@@ -1,0 +1,5 @@
+class AddTablesWidgetToWebpage < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webpages, :tables_widget, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161228215134) do
+ActiveRecord::Schema.define(version: 20170327182543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -454,6 +454,7 @@ ActiveRecord::Schema.define(version: 20161228215134) do
     t.boolean  "noimageindex",           default: false
     t.string   "dynamic_yield_sku"
     t.string   "dynamic_yield_category"
+    t.jsonb    "tables_widget"
     t.index ["user_id"], name: "index_webpages_on_user_id", using: :btree
   end
 


### PR DESCRIPTION
**Purpose:**
This implements the beginnings of a legacy widget system, starting with a 'Tables Widget'. This allows a content creator to input a YAML-formatted set of data in the Webpage 'Widgets' tab.

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1049

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * *Yes - please run migrations*
  
* Library changes
  * N/A

* Side effects
  * Upon deploy to Staging/Production, the Snippets that contained the data used to power dynamic Tables will no longer be available. This data will have to be migrated to the new system. Additionally, PO documentation will need to be updated.

**Screenshots**
* Before
N/A

* After
![image](https://cloud.githubusercontent.com/assets/1045168/24375393/af318514-12fd-11e7-8d13-94933c0c389f.png)

**QA Links:**
* http://web.cortex-2.development.c66.me/
* http://web.employer-4.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * Edit/Create a Webpage on Cortex (use the QA link with `admin@cortexcms.org`/`welcome1` credentials) with an applicable Tables Widget (for example, http://web.employer-4.development.c66.me/portal/EPWHG)
  * Try inputting some example YAML data in the Widgets tab. For example, for an APS page:
```yaml
---
aps:
- section_heading: A Product Table
  items_heading: Items
  price_heading: Price
  products:
  - name: Item A1
    description: This is a description of Item A!
    price: 42
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
    value: Save $10!
  - name: Item B1
    description: This is a nifty description of Item B!
    price: 43
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
  - name: Item B1
    description: This is a nifty description of Item B!
    price: 43
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
- section_heading: Another Product Table
  items_heading: Items
  price_heading: Price
  products:
  - name: Item A2
    description: This is a description of Item A!
    price: 42
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
    value: Save $10!
  - name: Item B2
    description: This is a nifty description of Item B!
    price: 43
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
```
  * Or for an eCom Promotions page:
```yaml
---
products:
- section_heading: A Promotions Table
  items_heading: Items
  price_heading: Price
  products:
  - name: Item A1
    description: This is a description of Item A!
    price: 42
    cart_url: https://employer.careerbuilder.com/ecommerce/global/addtocart.aspx
    value: Save $10!
```
* Save!
* *Witness* that the Table now appears on the page
* Try breaking the table with some invalid YAML
* *Witness* that the page still renders, but with a Table that produces an error

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/736
https://github.com/cortex-cms/cortex-snippets-client-ruby/pull/29

**Additional Information**
N/A