### PR TITLE
Ignore C66 Puma Restart Errors

### DIFF
--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -38,7 +38,7 @@ default: &default
       destination: /tmp/rebuild_indexes.sh
       target: rails
       execute: true
-    - command: cd $STACK_PATH && bundle exec pumactl -P /tmp/web_server.pid restart
+    - command: cd $STACK_PATH && bundle exec pumactl -P /tmp/web_server.pid restart || true
       target: rails
       sudo: true
       run_on: all_servers


### PR DESCRIPTION
**Purpose:**
C66 will no longer break during deploy if `/tmp/web_server.pid` doesn't exist during Puma restart hook. This is hunkey-dorey, because C66 actually removes servers from the load-balancer one-by-one as they are deployed, shutting down the Rails server entirely - thereby removing the `pid` file. This behavior is correct and this hook still catches the edge case it was intended for - restarting Puma when it fails to stop for unknown reasons.

**JIRA:**
N/A

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A

* After
N/A

**QA Links:**
N/A

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * N/A

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies:**
N/A

**Additional Information**
N/A