### PR TITLE
COR-742 and 743: RSS Fixes

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -69,11 +69,9 @@ class ContentItem < ApplicationRecord
     Date.parse(date).rfc2822
   end
 
-  def user_email(user_field_id)
-    user_id = field_items.find_by_field_id(user_field_id).data.values.join
-    user_email = User.find_by_id(user_id).try(:email)
-    user_fullname = User.find_by_id(user_id).try(:fullname)
-    "#{user_email} (#{user_fullname})"
+  def rss_author(field_id)
+    author = field_items.find_by_field_id(field_id).data["author_name"]
+    "editorial@careerbuilder.com (#{author})"
   end
 
   # The Method self.taggable_fields must always be above the acts_as_taggable_on inclusion for it.

--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -364,7 +364,7 @@ namespace :employer do
             }
           },
           "author": { "method": {
-            "name": "user_email",
+            "name": "rss_author",
             "args": [blog.fields.find_by_name('Author').id]
             }
           },


### PR DESCRIPTION
## **Purpose:**
Fixes for RSS feed not importing into Uberflip
* Includes #477 which removes encoding on author element
* Updates `<author>` field to work with the revised user system
   * Uses approved generic email address for all authors: editorial@careerbuilder.com
* Updates `<pubDate>` with RFC 2822 format

## On Prod
**Need to reseed, add new sample posts, import into Uberflip before story can be verified**

## **JIRA:**

https://cb-content-enablement.atlassian.net/browse/COR-742
https://cb-content-enablement.atlassian.net/browse/COR-743

Original Bug: https://cb-content-enablement.atlassian.net/browse/COR-691

## **Changes:**
* Changes to setup, Architectural changes, Migrations, Library changes, Side effects
  * n/a

## **Screenshots**
* **Before**: Imagine RSS validator and Uberflip RSS import failing

* **After**: The XML below (see details)

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:media="http://search.yahoo.com/mrss/">
  <channel>
    <link>http://resources.careerbuilder.com</link>
    <title>Employer Blog</title>
    <language>en-US</language>
    <description>News and trends, best practices, product news and more from CareerBuilder's experts.</description>
    <item>
      <link>https://resources.careerbuilder.com/this-is-a-slug-with-no-special-characters-it-is-hand-made</link>
      <title>this is clicking more than once and ending on scheduled stupid title</title>
      <author>cortex@cortex.com (Cortex Admin)</author>
      <content:encoded>
        <![CDATA[<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance.</p>

<p>The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.</p>
]]>
      </content:encoded>
      <pubDate>Mon, 10 Apr 2017 00:00:00 +0000</pubDate>
      <category>Recruitment Solutions</category>
      <media:content url="http://localhost:3000/asset_field_types/assets/lorem_ipsum-original.png?1491840227" type="image/png" medium="image" width="284" height="177"/>
    </item>
  </channel>
</rss>
```

</details>


Now passes validation:

![image](https://cloud.githubusercontent.com/assets/2359538/24871639/e60e7e10-1ddf-11e7-9e4e-ebe79169a2ac.png)

And imports into Uberflip:

![image](https://cloud.githubusercontent.com/assets/2359538/24871647/f09a36d0-1ddf-11e7-86a8-d65d85528c7a.png)


## **QA Links:**
n/a

## **How to Verify These Changes**
* Specific pages to visit
  * n/a

* Steps to take
  * Copy the XML from `details` above
  * Serve it from your public folder or somewhere
  * Run it through an [RSS validator](https://validator.w3.org/feed). It should pass
  * Import it into Uberflip (in the Content area add a new stream). You should see your content in Uberflip

* Responsive considerations
  * n/a


## **Relevant PRs/Dependencies:**
https://github.com/cbdr/cortex/pull/477

## **Additional Information**
n/a