### PR TITLE
COR-763: Uniqueness Breaks When Updating

### DIFF
--- a/app/services/content_item_service.rb
+++ b/app/services/content_item_service.rb
@@ -33,7 +33,7 @@ class ContentItemService < ApplicationService
     @content_item = ContentItem.find(id)
 
     transact_and_refresh do
-      @content_item.update(content_item_attributes)
+      @content_item.assign_attributes(content_item_attributes)
     end
   end
 


### PR DESCRIPTION
## Purpose:
Previously in Cortex we had a bug that would cause any text field with a uniqueness validation to break when the content of the field is updated (throw errors when there shouldn't be). The cause for this is the fact we're saving twice in our Service layer, which causes the field to be compared to its current self, which is bad.

> In Cortex Beta, if you attempt to alter an existing Title or Slug that validates uniqueness (for example, Media Title or Blog Slug), the system breaks.

## JIRA:
https://cb-content-enablement.atlassian.net/browse/COR-763

## Steps to Take On Prod
* Create a Media
* Update the title of that media
* If it doesn't error incorrectly, then this works

## Changes:
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * N/A

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
http://web.cortex-3.development.c66.me

## How to Verify These Changes
* Specific pages to visit
  * Create Media or Blog

* Steps to take
  * Create a content item
  * Now go back to that content item and edit uniquely validated fields (Slug for Blog, Title for Media)
  * Save the content item and confirm there are no errors

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
N/A

## Additional Information
Additionally it wouldn't hurt to double check the media shortcode system for our WYSIWYG. To do that please make a Blog and attach a piece of media to the WYSIWYG, then save it. You should be able to go back and see the media inserted correctly.