### PR TITLE
COR-781: Rearrange RSS Feed

### DIFF
--- a/lib/tasks/employer/blog.rake
+++ b/lib/tasks/employer/blog.rake
@@ -379,12 +379,12 @@ namespace :employer do
             "args": [blog.fields.find_by_name('Categories').id]
             }, "multiple": ","
           },
-          "content": { "field": blog.fields.find_by_name('Body').id, "encode": true },
           "media:content": { "media":
             { "field": blog.fields.find_by_name('Featured Image').id,
               "medium": "image"
             }
-          }
+          },
+          "content": { "field": blog.fields.find_by_name('Body').id, "encode": true }
         }
       }
 


### PR DESCRIPTION
## Purpose:
Move the Feature Image above the Body in the RSS Decorator

> We need to move the featured image data above the post body data in our feed from Cortex so that Uberflip can potentially recognize the first image in a passed item as our featured image and still retain the body images without making them the tiles.

## JIRA:
https://cb-content-enablement.atlassian.net/browse/COR-781

## Steps to Take On Prod
N/A

## Changes:
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * N/A

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
N/A

## How to Verify These Changes
* Specific pages to visit
  * N/A

* Steps to take
  * N/A

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
N/A

## Additional Information
N/A