### PR TITLE
COR-785: Agnostic Webpage URLs

### DIFF
--- a/app/interactors/get_webpage_feed.rb
+++ b/app/interactors/get_webpage_feed.rb
@@ -4,15 +4,7 @@ class GetWebpageFeed
   def call
     webpage = ::Webpage
     webpage = webpage.find_by_tenant_id(context.tenant) if context.tenant
-    webpage = webpage.find_by_protocol_agnostic_url(protocol_agnostic_url(context.params.url))
+    webpage = webpage.find_by_protocol_agnostic_url(webpage.protocol_agnostic_url(context.params.url))
     context.webpage = webpage
-  end
-
-  private
-
-  def protocol_agnostic_url(url)
-    uri = Addressable::URI.parse(url)
-    path = uri.path == '/' ? uri.path : uri.path.chomp('/')
-    "://#{uri.authority}#{path}"
   end
 end


### PR DESCRIPTION
## Purpose:
Webpages created in Cortex with a URL that includes any URL parameters or "jump-links" (anything after ? or # really) 404s when queried with the base version of that URL. This is causing legitimate pages from Employer to fail when querying Cortex.

The cause of the bug was [this scope](https://github.com/cbdr/cortex/blob/develop/app/models/webpage.rb#L7), which wasn't matching the stripped URL against its full, parameterized counterpart. I removed / rebuilt the scope into a class method of the same name and compared the stripped URL against a series of equally stripped URLs, which is showing the correct results, regardless of URL extraneousness.

> Currently, if you set a Webpage's URL in Cortex (to, say, https://hiring.careerbuilder.com/recruiting-solutions/job-postings?disable_redirects=1), and then request that URL via Cortex's Webpage feed (i.e. grabbing https://hiring.careerbuilder.com/recruiting-solutions/job-postings from the feed), it will 404.

## JIRA:
https://cb-content-enablement.atlassian.net/browse/COR-785

## Steps to Take On Prod
* Go to any URL with params in the URL (when created in cortex)
* Confirm snippets are loading on that page

## Changes:
* Changes to setup
  * Rebuild `find_by_protocol_agnostic_url` scope into class method of the same name

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * N/A

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
http://web.cortex-5.development.c66.me

## How to Verify These Changes
* Specific pages to visit
  * See below for detailed instructions

* Steps to take
  * Go into Cortex and create two URLs
     1. `/job-postings?disable_redirects=1`
     2. `/job-postings/integration-partners?disable_redirects=1`
  * Add recognizable content to the snippets of each page (to help identify them)
  * Visit `/job-postings` in Employer
  * Confirm that you have correctly pulled the snippets for that page
  * Now visit `/job-postings/integration-partners` in Employer
  * Confirm you have the correct snippets for that page (and not the other page we created) 

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
N/A

## Additional Information
N/A