### PR TITLE
COR-785: 'Agnostic' Webpage URLs

### DIFF
--- a/app/interactors/get_webpage_feed.rb
+++ b/app/interactors/get_webpage_feed.rb
@@ -4,7 +4,16 @@ class GetWebpageFeed
   def call
     webpage = ::Webpage
     webpage = webpage.find_by_tenant_id(context.tenant) if context.tenant
-    webpage = webpage.agnostic_find_by_url(context.params.url).first
+    webpage = webpage.agnostic_find_by_url(context.params.url)
+    
     context.webpage = webpage
+  end
+
+  private
+
+  def protocol_agnostic_url(url)
+    uri = Addressable::URI.parse(url)
+    path = uri.path == '/' ? uri.path : uri.path.chomp('/')
+    "://#{uri.authority}#{path}"
   end
 end

--- a/app/interactors/get_webpage_feed.rb
+++ b/app/interactors/get_webpage_feed.rb
@@ -4,15 +4,7 @@ class GetWebpageFeed
   def call
     webpage = ::Webpage
     webpage = webpage.find_by_tenant_id(context.tenant) if context.tenant
-    webpage = webpage.find_by_protocol_agnostic_url(protocol_agnostic_url(context.params.url)).first
+    webpage = webpage.agnostic_find_by_url(context.params.url).first
     context.webpage = webpage
-  end
-
-  private
-
-  def protocol_agnostic_url(url)
-    uri = Addressable::URI.parse(url)
-    path = uri.path == '/' ? uri.path : uri.path.chomp('/')
-    "://#{uri.authority}#{path}"
   end
 end

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -5,7 +5,7 @@ class Webpage < ApplicationRecord
   serialize :tables_widget
   serialize :charts_widget
 
-  scope :find_by_protocol_agnostic_url, ->(suffix) { where('url LIKE :suffix', suffix: "%#{suffix}") }
+  scope :agnostic_find_by_url, ->(url) { where('url ~* ?', "(?:[-\w]+\.)+[-\w]+(?::\d+)?(?:\/[^#?]*)") }
 
   acts_as_paranoid
   acts_as_taggable_on :seo_keywords

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -17,8 +17,8 @@ class Webpage < ApplicationRecord
   accepts_nested_attributes_for :snippets
 
   def self.agnostic_find_by_url(url)
-    url = protocol_agnostic_url url
-    agnostic_guess_by_url.find { |webpage| protocol_agnostic_url(webpage.url) == url }
+    url = protocol_agnostic_url(url)
+    agnostic_guess_by_url(url).find { |webpage| protocol_agnostic_url(webpage.url) == url }
   end
 
   def tables_widget_yaml

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -5,7 +5,7 @@ class Webpage < ApplicationRecord
   serialize :tables_widget
   serialize :charts_widget
 
-  scope :agnostic_find_by_url, ->(url) { where('url ~* ?', "(?:[-\w]+\.)+[-\w]+(?::\d+)?(?:\/[^#?]*)") }
+  scope :agnostic_guess_by_url, ->(url) { where('url LIKE :url', url: "%#{url}%") }
 
   acts_as_paranoid
   acts_as_taggable_on :seo_keywords
@@ -15,6 +15,11 @@ class Webpage < ApplicationRecord
   has_many :documents, through: :snippets, :dependent => :destroy
 
   accepts_nested_attributes_for :snippets
+
+  def self.agnostic_find_by_url(url)
+    url = protocol_agnostic_url url
+    agnostic_guess_by_url.find { |webpage| protocol_agnostic_url(webpage.url) == url }
+  end
 
   def tables_widget_yaml
     tables_widget.to_yaml
@@ -62,5 +67,13 @@ class Webpage < ApplicationRecord
 
   def accordion_group_widget_json= p
     self.accordion_group_widget = JSON.parse(p, quirks_mode: true) # Quirks mode will let us parse a null JSON object
+  end
+
+  private
+
+  def self.protocol_agnostic_url(url)
+    uri = Addressable::URI.parse(url)
+    path = uri.path == '/' ? uri.path : uri.path.chomp('/')
+    "://#{uri.authority}#{path}"
   end
 end

--- a/semaphore_ci/setup.sh
+++ b/semaphore_ci/setup.sh
@@ -16,18 +16,6 @@ bundle exec rake bower:install:development
 echo "bundle exec rake webpack:ensure_assets_compiled"
 bundle exec rake webpack:ensure_assets_compiled
 
-echo "ES Install"
-sudo service elasticsearch stop
-if ! [ -e .semaphore-cache/elasticsearch-2.4.1.deb ]; then (cd .semaphore-cache; curl -OL https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-2.4.1.deb); fi
-sudo dpkg -i --force-confnew .semaphore-cache/elasticsearch-2.4.1.deb
-sudo service elasticsearch start
-
-echo "sleep 5"
-sleep 5
-
-echo "ES Version Check"
-curl -XGET 'http://localhost:9200'
-
 echo "bundle exec rake db:setup"
 bundle exec rake db:setup
 


### PR DESCRIPTION
## Purpose:
This PR implements a strategy to performantly find a matching URL for a Webpage that is agnostic of not only its scheme (which already was implemented), but also its parameters (`?`) and anchors (`#`). Originally, a regex approach via Postgres was attempted that proved too convoluted and complex. Instead, we've ended with a compromise: a speedy scope that churns out best-guess matches for the URL in question, then a slow class method that refines those guesses and provides an exact match. A previous PR featured a similar implementation, but lacked the best-guess scope - this meant it had to load and loop through every Webpage in the system until it found an exact match.

To better explain why we can't just use the buest-guess scope, consider the following three URLs:
* `https://hiring.careerbuilder.com/contact-us`
* `https://hiring.careerbuilder.com/contact-us-today`
* `https://hiring.careerbuilder.com/contact-me`

If the search term was `hiring.careerbuilder.com/contact-us`, the scope would properly exclude `contact-me`. However, because the scope will match any character on either side of the search term, the first two results are returned in the record set. This is why the class method exists - to refine these results.

## JIRA:
https://cb-content-enablement.atlassian.net/browse/COR-785

## Steps to Take On Prod
N/A

## Changes:
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * N/A

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
* http://web.cortex-1.development.c66.me/
* http://web.employer-3.development.c66.me/

## How to Verify These Changes
* Specific pages to visit
  * N/A - See above

* Steps to take
  * In Cortex, try adding a few Webpages that mimick the scenario mentioned above. Ensure snippets are loaded properly, even for URLs with `?params` and `#anchors`.

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
N/A

## Additional Information
N/A