### PR TITLE
EM-1647: Cannot Edit Jobs Control Page

### DIFF
--- a/app/assets/javascripts/legacy/controllers/webpages/edit.js
+++ b/app/assets/javascripts/legacy/controllers/webpages/edit.js
@@ -72,4 +72,16 @@ angular.module('cortex.controllers.webpages.edit', [
         page: page.page
       });
     }
+
+    $scope.appendEditingModeToUrl = function(url) {
+      var urlHasParams = _.includes(url, '?');
+
+      if (urlHasParams) {
+        url = url + '&editing_mode=1';
+      } else {
+        url = url + '?editing_mode=1';
+      }
+
+      return url;
+    }
   });

--- a/app/assets/legacy_templates/webpages/edit.html
+++ b/app/assets/legacy_templates/webpages/edit.html
@@ -129,6 +129,6 @@
     </tab>
   </tabset>
 
-  <iframe class="webpage-frame" id="webpage-frame"
-          ng-src="{{ data.webpage.url + '?editing_mode=1' | trustAsResourceUrl }}" disabled></iframe>
+  <iframe ng-if="data.webpage.url" class="webpage-frame" id="webpage-frame"
+          ng-src="{{ appendEditingModeToUrl(data.webpage.url) | trustAsResourceUrl }}" disabled></iframe>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -472,8 +472,8 @@ ActiveRecord::Schema.define(version: 20170531215319) do
     t.string   "dynamic_yield_sku"
     t.string   "dynamic_yield_category"
     t.jsonb    "tables_widget"
-    t.jsonb    "accordion_group_widget"
     t.jsonb    "charts_widget"
+    t.jsonb    "accordion_group_widget"
     t.index ["user_id"], name: "index_webpages_on_user_id", using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,9 +12,7 @@ initial_post = Post.find_by_slug(initial_post_seed.slug) || ArticlePost.new(titl
                                                                             job_phase: initial_post_seed.job_phase,
                                                                             display: initial_post_seed.display,
                                                                             copyright_owner: initial_post_seed.copyright_owner,
-                                                                            categories: [Category.first],
-                                                                            primary_category: Category.first,
-                                                                            author: User.first)
+                                                                            author: Author.first)
 
 existing_tenant = Tenant.find_by_name(tenant_seed.name)
 


### PR DESCRIPTION
## Purpose:
Implements `appendEditingModeToUrl` so that `ng-src` doesn't append two `?` characters to URLs that already have params, which was triggering a redirect and breaking IPE.

## JIRA:
https://cb-content-enablement.atlassian.net/browse/EM-1647

## Steps to Take On Prod
N/A

## Changes:
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * N/A

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
N/A - this is getting an expedited merge + hotfix

## How to Verify These Changes
* Specific pages to visit
  * N/A

* Steps to take
  * N/A

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
N/A

## Additional Information
This is getting an expedited merge and hotfix so Stephanie can update the Jobs page, which has a typo.