### PR TITLE
bugfix: YAML Codemirror Editor Disable Tabs Default

### DIFF
--- a/app/assets/javascripts/legacy/controllers/webpages/edit.js
+++ b/app/assets/javascripts/legacy/controllers/webpages/edit.js
@@ -36,7 +36,7 @@ angular.module('cortex.controllers.webpages.edit', [
        lineNumbers: true,
        autofocus: true,
        styleActiveLine: true,
-       indentWithTabs: true,
+       indentWithTabs: false,
        tabSize: 2,
        readOnly: false,
        lineWrapping : true,

--- a/app/assets/javascripts/legacy/controllers/webpages/edit.js
+++ b/app/assets/javascripts/legacy/controllers/webpages/edit.js
@@ -40,7 +40,13 @@ angular.module('cortex.controllers.webpages.edit', [
        tabSize: 2,
        readOnly: false,
        lineWrapping : true,
-       mode: 'yaml'
+       mode: 'yaml',
+       extraKeys: {
+        Tab: function(cm) {
+          var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
+          cm.replaceSelection(spaces);
+        }
+      }
      };
 
      $scope.selectedTab = 0;


### PR DESCRIPTION
**Purpose**
There was a bug that whenever someone copied a line and then repasted it, the editor would not save. Additionally using the tab key to indent two spaces was actually saved as invalid YAML. 

**JIRA**


**Changes**
* Improvements and fixes
  * I changed the the ui-codemirror option `indentWithTabs` to false
  * I added a codemirror callback that replaces `Tab` characters with spaces. 

* Changes to developer setup/environment
  * 

* Architectural changes
  * 

* Migrations or Steps to Take on Production
  * 
  
* Library changes
  * 

* Side effects
  * 

**Screenshots**
* Before

* After

**Feature Server**


**How to Verify These Changes**
* Specific pages to visit
  * 

* Steps to take
  *  Go to http://dev.admin.cbcortex.com/legacy#/webpages and try and use tabs, or copy a chunk of code and paste it again in the Code Mirror editor. 

* Responsive considerations
  * 

**Relevant PRs/Dependencies**
  * 

**Additional Information**

I made the mistake of setting `indentWithTabs` to true. Here is the Code Mirror docs: https://codemirror.net/doc/manual.html