### PR TITLE
CE-612: Incorrect Carotene Code Formatting

### DIFF
--- a/db/migrate/20180108184655_fix_carotene_code_formatting.rb
+++ b/db/migrate/20180108184655_fix_carotene_code_formatting.rb
@@ -1,0 +1,15 @@
+require 'csv'
+
+class FixCaroteneCodeFormatting < ActiveRecord::Migration[5.0]
+  def change
+    new_carotenes = CSV.read(Rails.root.join('db/seeds/carotene_v3.1.csv'), {headers: true, col_sep: ','})
+
+    CSV.foreach(Rails.root.join('db/seeds/carotene_v3.1_old.csv'), {headers: true, col_sep: ','}) do |carotene|
+      record = Carotene.find_by(title: carotene['GroupTitle'].strip, code: carotene['CID'].strip)
+
+      new_carotene = new_carotenes.find {|row| row['ID'] == carotene['ID']}
+      record.code = new_carotene['CID'].strip
+      record.save!
+    end
+  end
+end

--- a/db/seeds/carotene_v3.1_old.csv
+++ b/db/seeds/carotene_v3.1_old.csv
@@ -1,5 +1,5 @@
 ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
-0,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",0,Sales Manager (Management),11.0
+0,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",0,Sales Manager (Management),11
 1,11,9000,Other Management Occupations,1,Project Manager (Management),11.1
 2,11,9000,Other Management Occupations,2,General Manager (Management),11.2
 3,11,9000,Other Management Occupations,3,Restaurant Manager (Management),11.3
@@ -9,7 +9,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 7,11,9000,Other Management Occupations,7,Program Manager (Management),11.7
 8,11,3000,Operations Specialties Managers,8,Operations Manager (Management),11.8
 9,11,3000,Operations Specialties Managers,9,Branch Manager,11.9
-10,11,9000,Other Management Occupations,10,District Manager,11.10
+10,11,9000,Other Management Occupations,10,District Manager,11.1
 11,11,3000,Operations Specialties Managers,11,Human Resources (HR) Manager (Management),11.11
 12,11,1000,Top Executives,12,Vice President (VP),11.12
 13,11,9000,Other Management Occupations,13,Business Development Manager (Management),11.13
@@ -19,7 +19,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 17,11,3000,Operations Specialties Managers,17,Director of Operations (Management),11.17
 18,11,1000,Top Executives,18,Store Manager (Management),11.18
 19,11,9000,Other Management Occupations,19,Property Manager,11.19
-20,11,9000,Other Management Occupations,20,Finance Manager,11.20
+20,11,9000,Other Management Occupations,20,Finance Manager,11.2
 21,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",21,Sales Director (Management),11.21
 22,11,3000,Operations Specialties Managers,22,Relationship Manager (Management),11.22
 23,11,9000,Other Management Occupations,23,Clinical Manager (Management),11.23
@@ -29,7 +29,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 27,11,9000,Other Management Occupations,27,Medical Director,11.27
 28,11,9000,Other Management Occupations,28,Assistant Director (Management),11.28
 29,11,9000,Other Management Occupations,29,Community Manager,11.29
-30,11,9000,Other Management Occupations,30,Construction Manager (Management),11.30
+30,11,9000,Other Management Occupations,30,Construction Manager (Management),11.3
 31,11,9000,Other Management Occupations,31,Risk Manager (Management),11.31
 32,11,3000,Operations Specialties Managers,32,Practice Manager,11.32
 33,11,9000,Other Management Occupations,33,Nurse Manager (Management),11.33
@@ -38,7 +38,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 36,11,3000,Operations Specialties Managers,36,Chief Financial Officer (CFO),11.36
 37,11,9000,Other Management Occupations,38,Clinical Research Coordinator,11.38
 38,11,3000,Operations Specialties Managers,39,Contract Manager (Management),11.39
-39,11,3000,Operations Specialties Managers,40,Audit Manager,11.40
+39,11,3000,Operations Specialties Managers,40,Audit Manager,11.4
 40,11,9000,Other Management Occupations,41,Office Manager (Management),11.41
 41,11,3000,Operations Specialties Managers,42,Director of Finance,11.42
 42,11,3000,Operations Specialties Managers,43,Credit Manager,11.43
@@ -48,7 +48,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 46,11,9000,Other Management Occupations,47,Supply Chain Manager,11.47
 47,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",48,Business Development Director,11.48
 48,11,3000,Operations Specialties Managers,49,Human Resources (HR) Director,11.49
-49,11,3000,Operations Specialties Managers,50,Purchasing Manager,11.50
+49,11,3000,Operations Specialties Managers,50,Purchasing Manager,11.5
 50,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",51,Account Director,11.51
 51,11,1000,Top Executives,52,Business Development Executive,11.52
 52,11,9000,Other Management Occupations,53,College President,11.53
@@ -67,7 +67,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 65,11,3000,Operations Specialties Managers,67,Plant Manager,11.67
 66,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",68,Brand Manager,11.68
 67,11,3000,Operations Specialties Managers,69,Human Resources (HR) Business Partner,11.69
-68,11,3000,Operations Specialties Managers,70,Systems Manager (Management),11.70
+68,11,3000,Operations Specialties Managers,70,Systems Manager (Management),11.7
 69,11,3000,Operations Specialties Managers,71,Procurement Manager,11.71
 70,11,9000,Other Management Occupations,72,Nursing Home Administrator,11.72
 71,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",73,Category Manager,11.73
@@ -76,7 +76,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 74,11,9000,Other Management Occupations,76,Financial Center Manager,11.76
 75,11,9000,Other Management Occupations,77,Portfolio Manager (Management),11.77
 76,11,9000,Other Management Occupations,78,Financial Reporting Manager,11.78
-77,11,9000,Other Management Occupations,80,Asset Manager,11.80
+77,11,9000,Other Management Occupations,80,Asset Manager,11.8
 78,11,3000,Operations Specialties Managers,82,Collections Manager,11.82
 79,11,3000,Operations Specialties Managers,83,Materials Manager,11.83
 80,11,3000,Operations Specialties Managers,84,Benefits Manager,11.84
@@ -85,14 +85,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 83,11,9000,Other Management Occupations,87,Care Manager,11.87
 84,11,9000,Other Management Occupations,88,Chief Operating Officer (COO),11.88
 85,11,3000,Operations Specialties Managers,89,Recruiting Manager,11.89
-86,11,9000,Other Management Occupations,90,Director of Engineering (Management),11.90
+86,11,9000,Other Management Occupations,90,Director of Engineering (Management),11.9
 87,11,9000,Other Management Occupations,93,Residential Manager,11.93
 88,11,3000,Operations Specialties Managers,94,Proposal Manager (Management),11.94
 89,11,9000,Other Management Occupations,95,Project Director,11.95
 90,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",96,Events Manager (Management),11.96
 91,11,3000,Operations Specialties Managers,98,Lending Manager,11.98
 92,11,3000,Operations Specialties Managers,99,Human Resources (HR) Leader (Management),11.99
-93,11,9000,Other Management Occupations,100,Compliance Officer,11.100
+93,11,9000,Other Management Occupations,100,Compliance Officer,11.1
 94,11,3000,Operations Specialties Managers,101,Treasury Manager,11.101
 95,11,9000,Other Management Occupations,102,Compliance Director,11.102
 96,11,9000,Other Management Occupations,103,Director of Education (Management),11.103
@@ -109,7 +109,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 107,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",117,Assistant Store Manager (Management),11.117
 108,11,3000,Operations Specialties Managers,118,Benefits Administrator,11.118
 109,11,9000,Other Management Occupations,119,Food Service Director,11.119
-110,11,9000,Other Management Occupations,120,Laboratory Manager (Management),11.120
+110,11,9000,Other Management Occupations,120,Laboratory Manager (Management),11.12
 111,11,1000,Top Executives,121,Revenue Manager,11.121
 112,11,9000,Other Management Occupations,122,Chief Nursing Officer,11.122
 113,11,3000,Operations Specialties Managers,124,Quality Control Manager,11.124
@@ -117,7 +117,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 115,11,9000,Other Management Occupations,126,Project Leader (Management),11.126
 116,11,3000,Operations Specialties Managers,127,Compensation Manager,11.127
 117,11,3000,Operations Specialties Managers,128,Director of Benefits and Compensation,11.128
-118,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",130,Engagement Manager,11.130
+118,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",130,Engagement Manager,11.13
 119,11,9000,Other Management Occupations,132,Assistant Vice President (AVP),11.132
 120,11,9000,Other Management Occupations,133,Division Director,11.133
 121,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",134,Director of Communications (Management),11.134
@@ -128,7 +128,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 126,11,9000,Other Management Occupations,144,Acute Care Manager,11.144
 127,11,3000,Operations Specialties Managers,147,Regional Operations Manager,11.147
 128,11,9000,Other Management Occupations,148,Patient Services Manager,11.148
-129,11,1000,Top Executives,150,Chief Executive Officer (CEO),11.150
+129,11,1000,Top Executives,150,Chief Executive Officer (CEO),11.15
 130,11,9000,Other Management Occupations,152,Loss Prevention Manager (Management),11.152
 131,11,9000,Other Management Occupations,153,Construction Superintendent,11.153
 132,11,9000,Other Management Occupations,155,Vice President (VP) of Sales,11.155
@@ -138,7 +138,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 136,11,3000,Operations Specialties Managers,165,Capture Manager,11.165
 137,11,9000,Other Management Occupations,167,Fitness Manager (Management),11.167
 138,11,9000,Other Management Occupations,168,Technical Director (Management),11.168
-139,11,3000,Operations Specialties Managers,170,Human Resources (HR) Administrator,11.170
+139,11,3000,Operations Specialties Managers,170,Human Resources (HR) Administrator,11.17
 140,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",171,Development Officer,11.171
 141,11,9000,Other Management Occupations,172,Director of Quality Management,11.172
 142,11,3000,Operations Specialties Managers,174,Maintenance Director,11.174
@@ -146,11 +146,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 144,11,9000,Other Management Occupations,177,Vice President (VP) of Operations,11.177
 145,11,9000,Other Management Occupations,178,Surgery Center Administrator,11.178
 146,11,3000,Operations Specialties Managers,179,Fleet Manager (Management),11.179
-147,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",180,Campaign Manager,11.180
+147,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",180,Campaign Manager,11.18
 148,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",184,Community Relations Director,11.184
 149,11,9000,Other Management Occupations,188,Property Administrator,11.188
 150,11,9000,Other Management Occupations,189,Child Care Center Director,11.189
-151,11,9000,Other Management Occupations,190,Vice President (VP) of Finance,11.190
+151,11,9000,Other Management Occupations,190,Vice President (VP) of Finance,11.19
 152,11,3000,Operations Specialties Managers,193,Tax Director (Management),11.193
 153,11,9000,Other Management Occupations,194,Catering Manager (Management),11.194
 154,11,9000,Other Management Occupations,195,Safety Director (Management),11.195
@@ -170,7 +170,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 168,11,9000,Other Management Occupations,216,Dietary Manager,11.216
 169,11,9000,Other Management Occupations,217,Director of Client Services,11.217
 170,11,3000,Operations Specialties Managers,218,Director of Manufacturing,11.218
-171,11,9000,Other Management Occupations,220,Environmental Services Manager (Management),11.220
+171,11,9000,Other Management Occupations,220,Environmental Services Manager (Management),11.22
 172,11,9000,Other Management Occupations,222,Food Service Manager (Management),11.222
 173,11,9000,Other Management Occupations,223,Director of Claims,11.223
 174,11,9000,Other Management Occupations,224,Director of Quality Assurance,11.224
@@ -183,7 +183,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 181,11,9000,Other Management Occupations,236,Residence Director,11.236
 182,11,3000,Operations Specialties Managers,237,Director of Application Development,11.237
 183,11,9000,Other Management Occupations,238,Real Estate Director,11.238
-184,11,9000,Other Management Occupations,240,Director of Analytics,11.240
+184,11,9000,Other Management Occupations,240,Director of Analytics,11.24
 185,11,3000,Operations Specialties Managers,241,Director of Procurement,11.241
 186,11,9000,Other Management Occupations,243,Audit Director,11.243
 187,11,9000,Other Management Occupations,247,Apartment Manager,11.247
@@ -205,7 +205,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 203,11,3000,Operations Specialties Managers,276,Analytics Manager (Management),11.276
 204,11,9000,Other Management Occupations,277,Regulatory Manager,11.277
 205,11,9000,Other Management Occupations,279,Behavioral Health Care Manager,11.279
-206,11,3000,Operations Specialties Managers,280,Distribution Manager,11.280
+206,11,3000,Operations Specialties Managers,280,Distribution Manager,11.28
 207,11,3000,Operations Specialties Managers,286,Manufacturing Manager (Management),11.286
 208,11,9000,Other Management Occupations,289,Hospitality Manager,11.289
 209,11,9000,Other Management Occupations,293,Regional Director,11.293
@@ -234,7 +234,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 232,11,9000,Other Management Occupations,331,Other Topics,11.331
 233,11,9000,Other Management Occupations,31277,Vice President (VP) of Engineering,11.31277
 234,11,9000,Other Management Occupations,30516,Vice President (VP) of Business Development,11.30516
-235,11,9000,Other Management Occupations,11760,Mobility Director,11.11760
+235,11,9000,Other Management Occupations,11760,Mobility Director,11.1176
 236,11,9000,Other Management Occupations,11096,Grants Administrator,11.11096
 237,11,3000,Operations Specialties Managers,11418,Director of Transportation,11.11418
 238,11,3000,Operations Specialties Managers,10598,Director of Training,11.10598
@@ -243,7 +243,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 241,11,9000,Other Management Occupations,10219,Director of Research,11.10219
 242,11,9000,Other Management Occupations,30682,Director of Regulatory Affairs,11.30682
 243,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31241,Director of Public Relations (Management),11.31241
-244,11,9000,Other Management Occupations,11200,Director of Patient Access,11.11200
+244,11,9000,Other Management Occupations,11200,Director of Patient Access,11.112
 245,11,3000,Operations Specialties Managers,11777,Director of Materials,11.11777
 246,11,9000,Other Management Occupations,11269,Director of Infrastructure,11.11269
 247,11,3000,Operations Specialties Managers,31329,Director of Information Management,11.31329
@@ -260,14 +260,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 258,11,3000,Operations Specialties Managers,10129,Technology Manager (Management),11.10129
 259,11,3000,Operations Specialties Managers,31381,Task Manager,11.31381
 260,11,3000,Operations Specialties Managers,31083,Systems Integration Manager,11.31083
-261,11,3000,Operations Specialties Managers,11530,Supplier Relationship Manager,11.11530
+261,11,3000,Operations Specialties Managers,11530,Supplier Relationship Manager,11.1153
 262,11,9000,Other Management Occupations,30977,Subcontracts Manager,11.30977
 263,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",30797,Strategy Leader,11.30797
 264,11,1000,Top Executives,30742,Store Director,11.30742
 265,11,3000,Operations Specialties Managers,30678,Sourcing Leader,11.30678
-266,11,1000,Top Executives,10370,Solutions Executive,11.10370
+266,11,1000,Top Executives,10370,Solutions Executive,11.1037
 267,11,9000,Other Management Occupations,31358,Shared Services Manager,11.31358
-268,11,9000,Other Management Occupations,11510,School Principal,11.11510
+268,11,9000,Other Management Occupations,11510,School Principal,11.1151
 269,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10261,Sales Administrator (Management),11.10261
 270,11,9000,Other Management Occupations,30933,Risk and Assurance Manager,11.30933
 271,11,9000,Other Management Occupations,10472,Resource Leader,11.10472
@@ -276,7 +276,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 274,11,3000,Operations Specialties Managers,10313,Reporting Manager,11.10313
 275,11,3000,Operations Specialties Managers,11174,Relations Officer,11.11174
 276,11,9000,Other Management Occupations,31192,Reimbursement Manager,11.31192
-277,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31250,Regional Sales Executive,11.31250
+277,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31250,Regional Sales Executive,11.3125
 278,11,9000,Other Management Occupations,31559,Professional Services Manager,11.31559
 279,11,3000,Operations Specialties Managers,11145,Product Line Manager,11.11145
 280,11,9000,Other Management Occupations,11228,Practice Coordinator,11.11228
@@ -288,16 +288,16 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 286,11,3000,Operations Specialties Managers,30966,Modeling Manager,11.30966
 287,11,9000,Other Management Occupations,31471,Medical Supervisor,11.31471
 288,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10415,Marketing Executive,11.10415
-289,11,3000,Operations Specialties Managers,31180,Investment Officer,11.31180
+289,11,3000,Operations Specialties Managers,31180,Investment Officer,11.3118
 290,11,9000,Other Management Occupations,11123,Intelligence Manager,11.11123
 291,11,3000,Operations Specialties Managers,10474,Improvement Manager,11.10474
 292,11,9000,Other Management Occupations,30945,Imaging Manager,11.30945
-293,11,9000,Other Management Occupations,30840,Hospital Area Manager,11.30840
+293,11,9000,Other Management Occupations,30840,Hospital Area Manager,11.3084
 294,11,9000,Other Management Occupations,30362,Healthcare Facility Administrator,11.30362
 295,11,9000,Other Management Occupations,10621,Health Service Executive,11.10621
 296,11,3000,Operations Specialties Managers,11391,Head of Operations,11.11391
 297,11,9000,Other Management Occupations,31252,Grants Manager,11.31252
-298,11,3000,Operations Specialties Managers,11180,Fund Administrator,11.11180
+298,11,3000,Operations Specialties Managers,11180,Fund Administrator,11.1118
 299,11,3000,Operations Specialties Managers,31261,Fulfillment Manager,11.31261
 300,11,3000,Operations Specialties Managers,30603,Financial Controller (Management),11.30603
 301,11,3000,Operations Specialties Managers,10963,Financial Administrator,11.10963
@@ -305,7 +305,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 303,11,9000,Other Management Occupations,31537,Distribution Group Leader,11.31537
 304,11,3000,Operations Specialties Managers,31201,Deployment Manager,11.31201
 305,11,9000,Other Management Occupations,31077,Club Manager,11.31077
-306,11,9000,Other Management Occupations,31130,Clinical Trials Manager,11.31130
+306,11,9000,Other Management Occupations,31130,Clinical Trials Manager,11.3113
 307,11,9000,Other Management Occupations,30939,Clinical Nutrition Manager,11.30939
 308,11,9000,Other Management Occupations,30875,Chief Medical Officer,11.30875
 309,11,9000,Other Management Occupations,11243,Chief Brand Officer,11.11243
@@ -324,7 +324,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 322,11,3000,Operations Specialties Managers,30677,Subcontracts Administrator,11.30677
 323,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10146,Strategy Manager,11.10146
 324,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10508,Sourcing Director,11.10508
-325,11,9000,Other Management Occupations,10400,Solutions Director,11.10400
+325,11,9000,Other Management Occupations,10400,Solutions Director,11.104
 326,11,9000,Other Management Occupations,10708,Research Administrator,11.10708
 327,11,9000,Other Management Occupations,10832,Reporting Leader,11.10832
 328,11,9000,Other Management Occupations,30701,Regulatory Affairs Manager,11.30701
@@ -336,7 +336,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 334,11,3000,Operations Specialties Managers,11219,Photo Department Manager,11.11219
 335,11,3000,Operations Specialties Managers,30888,Optimization Manager,11.30888
 336,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10229,Marketing Leader,11.10229
-337,11,3000,Operations Specialties Managers,31310,Initiatives Manager,11.31310
+337,11,3000,Operations Specialties Managers,31310,Initiatives Manager,11.3131
 338,11,3000,Operations Specialties Managers,31427,Information Systems Manager,11.31427
 339,11,9000,Other Management Occupations,31324,Informatics Manager,11.31324
 340,11,9000,Other Management Occupations,30854,Implementation Leader,11.30854
@@ -365,7 +365,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 363,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",11673,Publications Manager,11.11673
 364,11,9000,Other Management Occupations,10763,Practice Director,11.10763
 365,11,9000,Other Management Occupations,30718,Practice Administrator,11.30718
-366,11,3000,Operations Specialties Managers,11500,Platform Manager,11.11500
+366,11,3000,Operations Specialties Managers,11500,Platform Manager,11.115
 367,11,9000,Other Management Occupations,31434,Planning Director (Management),11.31434
 368,11,9000,Other Management Occupations,11117,Partnership Director,11.11117
 369,11,3000,Operations Specialties Managers,31231,Outcomes Manager,11.31231
@@ -376,13 +376,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 374,11,9000,Other Management Occupations,10909,Compliance Administrator,11.10909
 375,11,9000,Other Management Occupations,10548,Communications Leader,11.10548
 376,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10628,Brand Director,11.10628
-377,11,9000,Other Management Occupations,11690,Architecture Director,11.11690
+377,11,9000,Other Management Occupations,11690,Architecture Director,11.1169
 378,11,3000,Operations Specialties Managers,30005,Programming Manager,11.30005
 379,11,9000,Other Management Occupations,11739,Science Director,11.11739
 380,11,9000,Other Management Occupations,31376,Regional Service Manager,11.31376
 381,11,3000,Operations Specialties Managers,30096,Process Manager (Management),11.30096
-382,11,9000,Other Management Occupations,10960,Policy Director,11.10960
-383,11,9000,Other Management Occupations,30110,Nurse Director,11.30110
+382,11,9000,Other Management Occupations,10960,Policy Director,11.1096
+383,11,9000,Other Management Occupations,30110,Nurse Director,11.3011
 384,11,9000,Other Management Occupations,11717,Intelligence Director,11.11717
 385,11,3000,Operations Specialties Managers,10327,Infrastructure Manager (Management),11.10327
 386,11,3000,Operations Specialties Managers,11696,Governance Manager,11.11696
@@ -405,13 +405,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 403,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",30762,Director of Revenue Management,11.30762
 404,11,9000,Other Management Occupations,30823,Deputy Director,11.30823
 405,11,3000,Operations Specialties Managers,11454,Credit Director,11.11454
-406,11,9000,Other Management Occupations,30150,Clinic Supervisor,11.30150
+406,11,9000,Other Management Occupations,30150,Clinic Supervisor,11.3015
 407,11,9000,Other Management Occupations,10125,Client Manager (Management),11.10125
 408,11,3000,Operations Specialties Managers,30635,Business Office Manager,11.30635
 409,11,3000,Operations Specialties Managers,31281,Application Support Manager,11.31281
 410,11,9000,Other Management Occupations,31411,Engineering Services Manager,11.31411
 411,11,1000,Top Executives,30105,Department Manager (Management),11.30105
-412,11,3000,Operations Specialties Managers,10180,Bank Manager,11.10180
+412,11,3000,Operations Specialties Managers,10180,Bank Manager,11.1018
 413,11,3000,Operations Specialties Managers,31384,Application Services Manager,11.31384
 414,11,3000,Operations Specialties Managers,31141,Actuarial Manager,11.31141
 415,11,9000,Other Management Occupations,30941,Vice President (VP) of Technology,11.30941
@@ -420,9 +420,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 418,11,3000,Operations Specialties Managers,31399,Workforce Manager,11.31399
 419,11,3000,Operations Specialties Managers,30872,Value Manager,11.30872
 420,11,3000,Operations Specialties Managers,31223,Transfer Manager,11.31223
-421,11,9000,Other Management Occupations,30870,Surgery Manager,11.30870
+421,11,9000,Other Management Occupations,30870,Surgery Manager,11.3087
 422,11,9000,Other Management Occupations,31178,Studio Manager,11.31178
-423,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31000,Social Media Manager (Management),11.31000
+423,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31000,Social Media Manager (Management),11.31
 424,11,3000,Operations Specialties Managers,31363,Server Manager,11.31363
 425,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31045,Public Relations Manager,11.31045
 426,11,9000,Other Management Occupations,11735,Platform Director,11.11735
@@ -431,7 +431,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 429,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31589,Franchise Manager,11.31589
 430,11,3000,Operations Specialties Managers,31392,Employee Relations Manager,11.31392
 431,11,3000,Operations Specialties Managers,11095,Director of Information Systems,11.11095
-432,11,9000,Other Management Occupations,11080,Director of Construction,11.11080
+432,11,9000,Other Management Occupations,11080,Director of Construction,11.1108
 433,11,3000,Operations Specialties Managers,31514,Data Analytics Manager,11.31514
 434,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31336,Client Solutions Executive,11.31336
 435,11,9000,Other Management Occupations,31416,Campus Manager,11.31416
@@ -465,7 +465,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 463,11,9000,Other Management Occupations,30128,Superintendent (Management),11.30128
 464,11,9000,Other Management Occupations,30845,Staff Officer (Management),11.30845
 465,11,3000,Operations Specialties Managers,10242,Software Development Manager (Management),11.10242
-466,11,3000,Operations Specialties Managers,10390,Shop Manager (Management),11.10390
+466,11,3000,Operations Specialties Managers,10390,Shop Manager (Management),11.1039
 467,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31564,Selling Manager (Management),11.31564
 468,11,9000,Other Management Occupations,11224,School Coordinator (Management),11.11224
 469,11,3000,Operations Specialties Managers,10492,Risk Officer (Management),11.10492
@@ -478,7 +478,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 476,11,3000,Operations Specialties Managers,30248,Controller (Management),11.30248
 477,11,9000,Other Management Occupations,30585,Compliance Coordinator (Management),11.30585
 478,11,3000,Operations Specialties Managers,30653,Commercial Banker (Management),11.30653
-479,11,1000,Top Executives,31500,Bakery Manager (Management),11.31500
+479,11,1000,Top Executives,31500,Bakery Manager (Management),11.315
 480,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",11221,Director of Advertising (Management),11.11221
 481,11,9000,Other Management Occupations,30692,Unit Leader (Management),11.30692
 482,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",10364,Sales Officer (Management),11.10364
@@ -486,8 +486,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 484,11,9000,Other Management Occupations,30645,Coding Manager (Management),11.30645
 485,11,3000,Operations Specialties Managers,11522,Client Administrator (Management),11.11522
 486,11,3000,Operations Specialties Managers,11212,Finance Officer (Management),11.11212
-487,11,9000,Other Management Occupations,31240,Nurse Manager Intensive Care Unit (ICU) (Management),11.31240
-488,11,9000,Other Management Occupations,30880,"Environmental, Health, and Safety (EHS) Manager (Management)",11.30880
+487,11,9000,Other Management Occupations,31240,Nurse Manager Intensive Care Unit (ICU) (Management),11.3124
+488,11,9000,Other Management Occupations,30880,"Environmental, Health, and Safety (EHS) Manager (Management)",11.3088
 489,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31371,Customer Experience Manager (Management),11.31371
 490,11,9000,Other Management Occupations,31442,Care Management Coordinator (Management),11.31442
 491,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",31161,Director of Talent Management (Management),11.31161
@@ -498,19 +498,19 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 496,11,9000,Other Management Occupations,1079,Director of Security (Management),11.1079
 497,11,3000,Operations Specialties Managers,1041,Administrative Officer,11.1041
 498,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",1051,Creative Director (Management),11.1051
-499,11,1000,Top Executives,1030,Chairman,11.1030
+499,11,1000,Top Executives,1030,Chairman,11.103
 500,11,9000,Other Management Occupations,1027,National Director,11.1027
 501,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",1062,Head of Strategy,11.1062
 502,11,9000,Other Management Occupations,1071,Chair of the Board,11.1071
 503,11,9000,Other Management Occupations,1034,Clinical Director (Management),11.1034
-504,11,3000,Operations Specialties Managers,1050,Head of Finance,11.1050
+504,11,3000,Operations Specialties Managers,1050,Head of Finance,11.105
 505,11,2000,"Advertising, Marketing, Promotions, Public Relations, and Sales Managers",1067,Director of Partnerships,11.1067
-506,11,1000,Top Executives,1060,Council Member,11.1060
+506,11,1000,Top Executives,1060,Council Member,11.106
 507,11,1000,Top Executives,1098,Senator,11.1098
 508,11,9000,Other Management Occupations,1052,Ambassador,11.1052
 509,11,9000,Other Management Occupations,1078,Chairperson (Management),11.1078
 510,11,9000,Other Management Occupations,1089,Department Director,11.1089
-511,11,3000,Operations Specialties Managers,1010,Business Partner (Management),11.1010
+511,11,3000,Operations Specialties Managers,1010,Business Partner (Management),11.101
 512,11,9000,Other Management Occupations,1016,Committee Chair,11.1016
 513,11,3000,Operations Specialties Managers,1048,Director of Quality,11.1048
 514,11,1000,Top Executives,1093,Mayor,11.1093
@@ -521,8 +521,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 519,11,3000,Operations Specialties Managers,1058,Investment Director,11.1058
 520,11,3000,Operations Specialties Managers,1059,Business Owner,11.1059
 521,11,9000,Other Management Occupations,1042,Committee Member,11.1042
-522,11,9000,Other Management Occupations,1090,Member of the Board of Directors,11.1090
-523,13,2000,Financial Specialists,0,Accountant,13.0
+522,11,9000,Other Management Occupations,1090,Member of the Board of Directors,11.109
+523,13,2000,Financial Specialists,0,Accountant,13
 524,13,1000,Business Operations Specialists,1,Recruiter,13.1
 525,13,2000,Financial Specialists,2,Business Analyst (Business and Financial Operations),13.2
 526,13,2000,Financial Specialists,3,Financial Analyst,13.3
@@ -532,14 +532,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 530,13,1000,Business Operations Specialists,7,Senior Buyer,13.7
 531,13,2000,Financial Specialists,8,Loan Officer,13.8
 532,13,2000,Financial Specialists,9,Personal Banker (Business and Financial Operations),13.9
-533,13,2000,Financial Specialists,10,Financial Advisor (Business and Financial Operations),13.10
+533,13,2000,Financial Specialists,10,Financial Advisor (Business and Financial Operations),13.1
 534,13,2000,Financial Specialists,12,Loan Originator,13.12
 535,13,2000,Financial Specialists,14,Credit Analyst,13.14
 536,13,1000,Business Operations Specialists,15,Claims Adjuster,13.15
 537,13,2000,Financial Specialists,16,Mortgage Banker,13.16
 538,13,1000,Business Operations Specialists,17,Compensation Analyst,13.17
 539,13,1000,Business Operations Specialists,19,Claims Examiner,13.19
-540,13,1000,Business Operations Specialists,20,Assistant Controller (Business and Financial Operations),13.20
+540,13,1000,Business Operations Specialists,20,Assistant Controller (Business and Financial Operations),13.2
 541,13,1000,Business Operations Specialists,21,Sales Management Trainee (Business and Financial Operations),13.21
 542,13,2000,Financial Specialists,22,Risk Analyst,13.22
 543,13,2000,Financial Specialists,23,Tax Analyst,13.23
@@ -556,7 +556,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 554,13,2000,Financial Specialists,37,Wealth Management Advisor,13.37
 555,13,2000,Financial Specialists,38,Financial Consultant,13.38
 556,13,2000,Financial Specialists,39,Treasury Analyst,13.39
-557,13,1000,Business Operations Specialists,40,Claims Analyst,13.40
+557,13,1000,Business Operations Specialists,40,Claims Analyst,13.4
 558,13,2000,Financial Specialists,41,Plant Controller,13.41
 559,13,1000,Business Operations Specialists,42,Training Manager (Business and Financial Operations),13.42
 560,13,1000,Business Operations Specialists,43,Contract Analyst,13.43
@@ -569,7 +569,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 567,13,1000,Business Operations Specialists,54,Insurance Claims Specialist,13.54
 568,13,2000,Financial Specialists,55,Financial Advisor Trainee,13.55
 569,13,2000,Financial Specialists,58,Tax Staff,13.58
-570,13,2000,Financial Specialists,60,Project Analyst (Business and Financial Operations),13.60
+570,13,2000,Financial Specialists,60,Project Analyst (Business and Financial Operations),13.6
 571,13,1000,Business Operations Specialists,61,Construction Estimator,13.61
 572,13,2000,Financial Specialists,62,Investment Analyst,13.62
 573,13,1000,Business Operations Specialists,63,Logistics Analyst (Business and Financial Operations),13.63
@@ -578,23 +578,23 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 576,13,1000,Business Operations Specialists,66,Contracts Manager,13.66
 577,13,1000,Business Operations Specialists,67,Sales Trainer,13.67
 578,13,1000,Business Operations Specialists,69,Kronos Analyst,13.69
-579,13,2000,Financial Specialists,70,Fraud Analyst,13.70
+579,13,2000,Financial Specialists,70,Fraud Analyst,13.7
 580,13,1000,Business Operations Specialists,71,Cost Estimator,13.71
 581,13,1000,Business Operations Specialists,72,Estimator (Business and Financial Operations),13.72
 582,13,1000,Business Operations Specialists,77,Processing Manager,13.77
 583,13,2000,Financial Specialists,79,Risk Manager (Business and Financial Operations),13.79
-584,13,2000,Financial Specialists,80,Audit Leader,13.80
+584,13,2000,Financial Specialists,80,Audit Leader,13.8
 585,13,1000,Business Operations Specialists,81,Senior Trainer,13.81
 586,13,1000,Business Operations Specialists,82,Training Instructor,13.82
 587,13,2000,Financial Specialists,83,Research Analyst (Business and Financial Operations),13.83
 588,13,1000,Business Operations Specialists,86,Business Partner (Business and Financial Operations),13.86
 589,13,1000,Business Operations Specialists,88,Purchasing Analyst,13.88
-590,13,1000,Business Operations Specialists,90,Branch Sales Manager,13.90
+590,13,1000,Business Operations Specialists,90,Branch Sales Manager,13.9
 591,13,2000,Financial Specialists,91,Portfolio Analyst,13.91
 592,13,1000,Business Operations Specialists,92,Healthcare Consultant,13.92
 593,13,1000,Business Operations Specialists,93,Compliance Consultant,13.93
 594,13,1000,Business Operations Specialists,99,Consulting Manager,13.99
-595,13,2000,Financial Specialists,100,Revenue Analyst,13.100
+595,13,2000,Financial Specialists,100,Revenue Analyst,13.1
 596,13,1000,Business Operations Specialists,101,Electrical Estimator,13.101
 597,13,2000,Financial Specialists,102,Workforce Analyst,13.102
 598,13,1000,Business Operations Specialists,103,Corporate Trainer,13.103
@@ -603,23 +603,23 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 601,13,1000,Business Operations Specialists,107,Project Estimator,13.107
 602,13,1000,Business Operations Specialists,108,Claims Manager (Business and Financial Operations),13.108
 603,13,1000,Business Operations Specialists,109,Sourcing Analyst,13.109
-604,13,2000,Financial Specialists,110,Loan Analyst,13.110
+604,13,2000,Financial Specialists,110,Loan Analyst,13.11
 605,13,1000,Business Operations Specialists,111,Senior Estimator,13.111
 606,13,2000,Financial Specialists,113,Tax Senior - Public,13.113
 607,13,2000,Financial Specialists,114,Derivatives FpML Analyst,13.114
 608,13,2000,Financial Specialists,117,Relationship Manager (Business and Financial Operations),13.117
-609,13,1000,Business Operations Specialists,120,Recovery Analyst,13.120
+609,13,1000,Business Operations Specialists,120,Recovery Analyst,13.12
 610,13,2000,Financial Specialists,125,Mortgage Processing Supervisor,13.125
 611,13,1000,Business Operations Specialists,126,Operations Consultant,13.126
 612,13,1000,Business Operations Specialists,127,Operations Support,13.127
-613,13,2000,Financial Specialists,130,Inventory Analyst,13.130
+613,13,2000,Financial Specialists,130,Inventory Analyst,13.13
 614,13,2000,Financial Specialists,131,PMO Analyst,13.131
 615,13,1000,Business Operations Specialists,133,Staffing Consultant,13.133
 616,13,1000,Business Operations Specialists,134,National Luminologist Trainer,13.134
 617,13,1000,Business Operations Specialists,135,SAP Consultant (Business and Financial Operations),13.135
 618,13,1000,Business Operations Specialists,137,ERP Consultant,13.137
 619,13,1000,Business Operations Specialists,139,Environmental Manager (Business and Financial Operations),13.139
-620,13,2000,Financial Specialists,140,Quantitative Analyst,13.140
+620,13,2000,Financial Specialists,140,Quantitative Analyst,13.14
 621,13,2000,Financial Specialists,141,Tax Director (Business and Financial Operations),13.141
 622,13,2000,Financial Specialists,143,Auditor,13.143
 623,13,2000,Financial Specialists,144,Assurance Manager,13.144
@@ -628,7 +628,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 626,13,1000,Business Operations Specialists,152,Staffing Manager (Business and Financial Operations),13.152
 627,13,1000,Business Operations Specialists,153,Logistics Engineer (Business and Financial Operations),13.153
 628,13,2000,Financial Specialists,157,Auto Appraiser,13.157
-629,13,2000,Financial Specialists,160,Tax Supervisor,13.160
+629,13,2000,Financial Specialists,160,Tax Supervisor,13.16
 630,13,2000,Financial Specialists,161,Mortgage Opener,13.161
 631,13,1000,Business Operations Specialists,162,Materials Analyst,13.162
 632,13,2000,Financial Specialists,163,Real Estate Appraiser,13.163
@@ -659,13 +659,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 657,13,1000,Business Operations Specialists,207,Assurance Services Senior Associate,13.207
 658,13,2000,Financial Specialists,208,Financial Planning Analyst,13.208
 659,13,1000,Business Operations Specialists,209,Sourcer,13.209
-660,13,1000,Business Operations Specialists,210,Logistics Manager (Business and Financial Operations),13.210
+660,13,1000,Business Operations Specialists,210,Logistics Manager (Business and Financial Operations),13.21
 661,13,2000,Financial Specialists,211,Real Estate Analyst,13.211
 662,13,1000,Business Operations Specialists,213,Insurance Adjuster,13.213
 663,13,1000,Business Operations Specialists,217,Mortgage Assistant (Business and Financial Operations),13.217
 664,13,1000,Business Operations Specialists,218,Customer Service Analyst,13.218
 665,13,1000,Business Operations Specialists,219,Auto Adjuster,13.219
-666,13,2000,Financial Specialists,220,Mortgage Analyst,13.220
+666,13,2000,Financial Specialists,220,Mortgage Analyst,13.22
 667,13,1000,Business Operations Specialists,221,Internal Consultant,13.221
 668,13,1000,Business Operations Specialists,224,Executive Recruiter,13.224
 669,13,1000,Business Operations Specialists,226,Lead Manager,13.226
@@ -675,14 +675,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 673,13,1000,Business Operations Specialists,244,Compliance Manager (Business and Financial Operations),13.244
 674,13,2000,Financial Specialists,248,Audit Consultant,13.248
 675,13,2000,Financial Specialists,249,Loan Consultant,13.249
-676,13,2000,Financial Specialists,250,Regulatory Analyst,13.250
+676,13,2000,Financial Specialists,250,Regulatory Analyst,13.25
 677,13,2000,Financial Specialists,258,Billing Analyst (Business and Financial Operations),13.258
 678,13,1000,Business Operations Specialists,262,Parts Analyst,13.262
 679,13,1000,Business Operations Specialists,263,Other Topics,13.263
 680,13,2000,Financial Specialists,11233,Mortgage Professional,13.11233
 681,13,1000,Business Operations Specialists,31122,Human Resources (HR) Consultant,13.31122
 682,13,1000,Business Operations Specialists,10319,Healthcare Analyst,13.10319
-683,13,2000,Financial Specialists,10450,Certified Public Accountant (CPA),13.10450
+683,13,2000,Financial Specialists,10450,Certified Public Accountant (CPA),13.1045
 684,13,1000,Business Operations Specialists,31219,Business Tax Consultant,13.31219
 685,13,2000,Financial Specialists,11377,Wholesale Underwriter,13.11377
 686,13,1000,Business Operations Specialists,11104,Transformation Consultant,13.11104
@@ -692,15 +692,15 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 690,13,1000,Business Operations Specialists,31521,Training Officer (Business and Financial Operations),13.31521
 691,13,1000,Business Operations Specialists,30437,Training Coordinator,13.30437
 692,13,1000,Business Operations Specialists,11164,Training Assistant,13.11164
-693,13,1000,Business Operations Specialists,10500,Training Analyst,13.10500
+693,13,1000,Business Operations Specialists,10500,Training Analyst,13.105
 694,13,1000,Business Operations Specialists,30611,Technical Advisor,13.30611
-695,13,2000,Financial Specialists,30230,Tax Accountant,13.30230
+695,13,2000,Financial Specialists,30230,Tax Accountant,13.3023
 696,13,2000,Financial Specialists,11231,Systems Accountant,13.11231
 697,13,2000,Financial Specialists,11177,Surety Underwriter,13.11177
 698,13,1000,Business Operations Specialists,30752,Supply Chain Planner,13.30752
 699,13,1000,Business Operations Specialists,11065,Structural Analyst,13.11065
 700,13,1000,Business Operations Specialists,11788,Strategic Consultant,13.11788
-701,13,2000,Financial Specialists,10480,Strategic Analyst,13.10480
+701,13,2000,Financial Specialists,10480,Strategic Analyst,13.1048
 702,13,1000,Business Operations Specialists,31214,Staff Consultant,13.31214
 703,13,1000,Business Operations Specialists,30726,Specialist Procurement,13.30726
 704,13,1000,Business Operations Specialists,30937,Sales Operations Analyst,13.30937
@@ -718,19 +718,19 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 716,13,2000,Financial Specialists,10561,Payroll Accountant,13.10561
 717,13,2000,Financial Specialists,30172,Mortgage Loan Originator,13.30172
 718,13,2000,Financial Specialists,31094,Metrics Analyst,13.31094
-719,13,1000,Business Operations Specialists,30790,Merchandise Planner,13.30790
+719,13,1000,Business Operations Specialists,30790,Merchandise Planner,13.3079
 720,13,1000,Business Operations Specialists,31156,Marketing Strategist,13.31156
 721,13,1000,Business Operations Specialists,30314,Marketing Consultant (Business and Financial Operations),13.30314
 722,13,1000,Business Operations Specialists,31321,Management Liaison,13.31321
 723,13,1000,Business Operations Specialists,10813,Logistics Technician,13.10813
 724,13,1000,Business Operations Specialists,10596,Logistics Operator,13.10596
-725,13,2000,Financial Specialists,11010,Life Insurance Underwriter,13.11010
+725,13,2000,Financial Specialists,11010,Life Insurance Underwriter,13.1101
 726,13,2000,Financial Specialists,11013,Lending Officer,13.11013
 727,13,1000,Business Operations Specialists,30889,Improvement Consultant,13.30889
 728,13,2000,Financial Specialists,11242,General Ledger Accountant,13.11242
 729,13,2000,Financial Specialists,30475,Financial Counselor,13.30475
 730,13,1000,Business Operations Specialists,11564,Executive Consultant,13.11564
-731,13,1000,Business Operations Specialists,11040,Event Director,13.11040
+731,13,1000,Business Operations Specialists,11040,Event Director,13.1104
 732,13,1000,Business Operations Specialists,10334,Event Coordinator,13.10334
 733,13,1000,Business Operations Specialists,11206,Energy Analyst,13.11206
 734,13,2000,Financial Specialists,30384,Cost Accountant,13.30384
@@ -749,16 +749,16 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 747,13,2000,Financial Specialists,10517,Staff Analyst,13.10517
 748,13,2000,Financial Specialists,30129,Staff Accountant,13.30129
 749,13,1000,Business Operations Specialists,10183,Sales Analyst,13.10183
-750,13,2000,Financial Specialists,11610,Reporting Accountant,13.11610
+750,13,2000,Financial Specialists,11610,Reporting Accountant,13.1161
 751,13,2000,Financial Specialists,11809,Property Analyst,13.11809
 752,13,2000,Financial Specialists,11339,Manufacturing Accountant,13.11339
 753,13,1000,Business Operations Specialists,31258,Logistics Planner,13.31258
 754,13,2000,Financial Specialists,30699,Loan Underwriter,13.30699
-755,13,2000,Financial Specialists,10820,Lending Underwriter,13.10820
+755,13,2000,Financial Specialists,10820,Lending Underwriter,13.1082
 756,13,2000,Financial Specialists,31057,Investment Consultant,13.31057
 757,13,2000,Financial Specialists,11239,Inventory Accountant,13.11239
 758,13,1000,Business Operations Specialists,31573,Information Management Analyst,13.31573
-759,13,1000,Business Operations Specialists,30740,Improvement Coordinator,13.30740
+759,13,1000,Business Operations Specialists,30740,Improvement Coordinator,13.3074
 760,13,1000,Business Operations Specialists,11779,Government Consultant,13.11779
 761,13,2000,Financial Specialists,11188,Fund Analyst,13.11188
 762,13,2000,Financial Specialists,11554,Finance Consultant,13.11554
@@ -766,7 +766,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 764,13,1000,Business Operations Specialists,11341,Relations Analyst,13.11341
 765,13,1000,Business Operations Specialists,11394,Rates Analyst,13.11394
 766,13,2000,Financial Specialists,10656,Property Accountant,13.10656
-767,13,2000,Financial Specialists,11520,Principal Accountant,13.11520
+767,13,2000,Financial Specialists,11520,Principal Accountant,13.1152
 768,13,2000,Financial Specialists,11582,Payment Analyst,13.11582
 769,13,2000,Financial Specialists,10868,Operations Accountant,13.10868
 770,13,1000,Business Operations Specialists,30056,Managing Consultant,13.30056
@@ -797,13 +797,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 795,13,2000,Financial Specialists,30751,Trust Administrator (Business and Financial Operations),13.30751
 796,13,1000,Business Operations Specialists,30791,Training Consultant (Business and Financial Operations),13.30791
 797,13,2000,Financial Specialists,10603,Trading Analyst (Business and Financial Operations),13.10603
-798,13,1000,Business Operations Specialists,10270,Trader (Business and Financial Operations),13.10270
+798,13,1000,Business Operations Specialists,10270,Trader (Business and Financial Operations),13.1027
 799,13,1000,Business Operations Specialists,30601,Team Member Trainer (Business and Financial Operations),13.30601
 800,13,1000,Business Operations Specialists,31385,Talent Manager (Business and Financial Operations),13.31385
 801,13,1000,Business Operations Specialists,30979,Systems Trainer (Business and Financial Operations),13.30979
 802,13,2000,Financial Specialists,10784,Statistical Analyst (Business and Financial Operations),13.10784
 803,13,2000,Financial Specialists,10492,Risk Officer (Business and Financial Operations),13.10492
-804,13,1000,Business Operations Specialists,31100,Process Improvement Analyst (Business and Financial Operations),13.31100
+804,13,1000,Business Operations Specialists,31100,Process Improvement Analyst (Business and Financial Operations),13.311
 805,13,2000,Financial Specialists,30158,Personal Financial Representative (Business and Financial Operations),13.30158
 806,13,1000,Business Operations Specialists,31029,Optimization Analyst (Business and Financial Operations),13.31029
 807,13,2000,Financial Specialists,31095,Mortgage Loan Coordinator (Business and Financial Operations),13.31095
@@ -822,11 +822,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 820,13,1000,Business Operations Specialists,11307,Monitoring Analyst (Business and Financial Operations),13.11307
 821,13,2000,Financial Specialists,10512,Modeling Analyst (Business and Financial Operations),13.10512
 822,13,1000,Business Operations Specialists,30585,Compliance Coordinator (Business and Financial Operations),13.30585
-823,13,2000,Financial Specialists,30140,Accounting Analyst (Business and Financial Operations),13.30140
+823,13,2000,Financial Specialists,30140,Accounting Analyst (Business and Financial Operations),13.3014
 824,13,2000,Financial Specialists,11139,Content Analyst (Business and Financial Operations),13.11139
 825,13,1000,Business Operations Specialists,30197,Consultant (Business and Financial Operations),13.30197
 826,13,2000,Financial Specialists,1041,Financial Planner,13.1041
-827,13,1000,Business Operations Specialists,1150,Human Resources (HR) Coordinator (Business and Financial Operations),13.1150
+827,13,1000,Business Operations Specialists,1150,Human Resources (HR) Coordinator (Business and Financial Operations),13.115
 828,13,1000,Business Operations Specialists,1183,Head of Training,13.1183
 829,13,1000,Business Operations Specialists,1114,Resource Coordinator,13.1114
 830,13,1000,Business Operations Specialists,1256,Product Analyst (Business and Financial Operations),13.1256
@@ -896,18 +896,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 894,13,2000,Financial Specialists,1184,Head of Accounting,13.1184
 895,13,1000,Business Operations Specialists,1105,Quality Specialist (Business and Financial Operations),13.1105
 896,13,1000,Business Operations Specialists,1169,Business Coach,13.1169
-897,13,2000,Financial Specialists,1120,Financial Manager,13.1120
+897,13,2000,Financial Specialists,1120,Financial Manager,13.112
 898,13,2000,Financial Specialists,1173,Group Accountant,13.1173
 899,13,1000,Business Operations Specialists,1123,Project Specialist (Business and Financial Operations),13.1123
 900,13,1000,Business Operations Specialists,1063,Contracts Analyst,13.1063
-901,13,2000,Financial Specialists,1090,Accounting Specialist,13.1090
+901,13,2000,Financial Specialists,1090,Accounting Specialist,13.109
 902,13,1000,Business Operations Specialists,2044,Events Supervisor,13.2044
 903,13,1000,Business Operations Specialists,2045,Events Manager (Business and Financial Operations),13.2045
 904,13,2000,Financial Specialists,2099,Insurance Advisor,13.2099
 905,13,2000,Financial Specialists,2108,Underwriter,13.2108
-906,13,1000,Business Operations Specialists,2030,Marketing Assistant (Business and Financial Operations),13.2030
+906,13,1000,Business Operations Specialists,2030,Marketing Assistant (Business and Financial Operations),13.203
 907,13,1000,Business Operations Specialists,2056,Logistics Supervisor,13.2056
-908,15,1000,Computer Occupations,0,Software Engineer,15.0
+908,15,1000,Computer Occupations,0,Software Engineer,15
 909,15,1000,Computer Occupations,1,Project Manager (Computer and Mathematical),15.1
 910,15,1000,Computer Occupations,2,Java Developer,15.2
 911,15,1000,Computer Occupations,3,Systems Engineer (Computer and Mathematical),15.3
@@ -917,7 +917,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 915,15,1000,Computer Occupations,7,.Net Developer,15.7
 916,15,1000,Computer Occupations,8,Network Engineer (Computer and Mathematical),15.8
 917,15,1000,Computer Occupations,9,Systems Analyst,15.9
-918,15,1000,Computer Occupations,10,Database Administrator,15.10
+918,15,1000,Computer Occupations,10,Database Administrator,15.1
 919,15,1000,Computer Occupations,11,Web Developer,15.11
 920,15,1000,Computer Occupations,12,Information Technology (IT) Help Desk Specialist,15.12
 921,15,1000,Computer Occupations,13,SQL Developer,15.13
@@ -927,7 +927,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 925,15,1000,Computer Occupations,17,Data Analyst,15.17
 926,15,1000,Computer Occupations,18,Information Technology (IT) Support Engineer,15.18
 927,15,1000,Computer Occupations,19,Security Engineer,15.19
-928,15,1000,Computer Occupations,20,Junior Software Engineer,15.20
+928,15,1000,Computer Occupations,20,Junior Software Engineer,15.2
 929,15,1000,Computer Occupations,21,Information Technology (IT) Network Administrator,15.21
 930,15,1000,Computer Occupations,22,Information Security Analyst,15.22
 931,15,1000,Computer Occupations,23,Solutions Architect,15.23
@@ -937,7 +937,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 935,15,2000,Mathematical Science Occupations,27,Operations Analyst (Computer and Mathematical),15.27
 936,15,1000,Computer Occupations,28,Technical Lead,15.28
 937,15,1000,Computer Occupations,29,Information Technology (IT) Project Coordinator,15.29
-938,15,1000,Computer Occupations,30,Network Analyst,15.30
+938,15,1000,Computer Occupations,30,Network Analyst,15.3
 939,15,1000,Computer Occupations,31,PHP Developer,15.31
 940,15,1000,Computer Occupations,32,Information Systems Security Engineer,15.32
 941,15,1000,Computer Occupations,34,Data Architect,15.34
@@ -946,7 +946,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 944,15,1000,Computer Occupations,37,Database Developer,15.37
 945,15,1000,Computer Occupations,38,Desktop Support Technician,15.38
 946,15,1000,Computer Occupations,39,Oracle Developer,15.39
-947,15,1000,Computer Occupations,40,Technical Analyst,15.40
+947,15,1000,Computer Occupations,40,Technical Analyst,15.4
 948,15,1000,Computer Occupations,41,PC Technician,15.41
 949,15,1000,Computer Occupations,42,Web Designer (Computer and Mathematical),15.42
 950,15,1000,Computer Occupations,43,Functional Analyst (Computer and Mathematical),15.43
@@ -956,7 +956,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 954,15,1000,Computer Occupations,47,Cloud Engineer Architect,15.47
 955,15,1000,Computer Occupations,48,Unix Administrator,15.48
 956,15,1000,Computer Occupations,49,Clinical Systems Analyst,15.49
-957,15,1000,Computer Occupations,50,SharePoint Administrator,15.50
+957,15,1000,Computer Occupations,50,SharePoint Administrator,15.5
 958,15,1000,Computer Occupations,51,Storage Engineer,15.51
 959,15,1000,Computer Occupations,52,User Experience Designer,15.52
 960,15,1000,Computer Occupations,53,Business Intelligence Developer,15.53
@@ -966,7 +966,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 964,15,1000,Computer Occupations,57,SAP Consultant (Computer and Mathematical),15.57
 965,15,1000,Computer Occupations,58,Application Architect,15.58
 966,15,1000,Computer Occupations,59,Server Administrator,15.59
-967,15,1000,Computer Occupations,60,Information Technology (IT) Field Technician,15.60
+967,15,1000,Computer Occupations,60,Information Technology (IT) Field Technician,15.6
 968,15,1000,Computer Occupations,62,Network Technician,15.62
 969,15,1000,Computer Occupations,63,Infrastructure Engineer,15.63
 970,15,1000,Computer Occupations,64,Virtualization Engineer,15.64
@@ -975,7 +975,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 973,15,1000,Computer Occupations,67,IOS Developer,15.67
 974,15,1000,Computer Occupations,68,Senior IT Consultant,15.68
 975,15,1000,Computer Occupations,69,Information Technology (IT) Support Manager,15.69
-976,15,1000,Computer Occupations,70,Software Architect,15.70
+976,15,1000,Computer Occupations,70,Software Architect,15.7
 977,15,1000,Computer Occupations,71,Configuration Analyst,15.71
 978,15,1000,Computer Occupations,72,Business Intelligence Architect,15.72
 979,15,1000,Computer Occupations,73,Firmware Engineer,15.73
@@ -984,7 +984,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 982,15,1000,Computer Occupations,77,Security Administrator,15.77
 983,15,1000,Computer Occupations,78,Data Modeler,15.78
 984,15,1000,Computer Occupations,79,Software Tester,15.79
-985,15,1000,Computer Occupations,80,Desktop Engineer,15.80
+985,15,1000,Computer Occupations,80,Desktop Engineer,15.8
 986,15,1000,Computer Occupations,81,NOC Technician,15.81
 987,15,1000,Computer Occupations,82,Database Engineer,15.82
 988,15,1000,Computer Occupations,83,Network Architect,15.83
@@ -992,7 +992,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 990,15,1000,Computer Occupations,87,Android Developer,15.87
 991,15,1000,Computer Occupations,88,Citrix Engineer,15.88
 992,15,1000,Computer Occupations,89,Python Developer,15.89
-993,15,1000,Computer Occupations,90,Web Administrator,15.90
+993,15,1000,Computer Occupations,90,Web Administrator,15.9
 994,15,1000,Computer Occupations,91,Information Technology (IT) Field Engineer,15.91
 995,15,1000,Computer Occupations,92,Release Engineer,15.92
 996,15,1000,Computer Occupations,93,Informatica Developer,15.93
@@ -1002,7 +1002,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1000,15,1000,Computer Occupations,97,Scrum Master,15.97
 1001,15,1000,Computer Occupations,98,Systems Technician (Computer and Mathematical),15.98
 1002,15,1000,Computer Occupations,99,Technical Consultant,15.99
-1003,15,1000,Computer Occupations,100,Identity Management Engineer,15.100
+1003,15,1000,Computer Occupations,100,Identity Management Engineer,15.1
 1004,15,1000,Computer Occupations,101,PeopleSoft Developer,15.101
 1005,15,1000,Computer Occupations,102,Avaya Engineer,15.102
 1006,15,1000,Computer Occupations,103,Graphics Software Engineer,15.103
@@ -1011,7 +1011,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1009,15,1000,Computer Occupations,106,Data Center Technician,15.106
 1010,15,1000,Computer Occupations,108,Salesforce Developer,15.108
 1011,15,1000,Computer Occupations,109,Validation Engineer (Computer and Mathematical),15.109
-1012,15,1000,Computer Occupations,110,Data Warehouse Developer,15.110
+1012,15,1000,Computer Occupations,110,Data Warehouse Developer,15.11
 1013,15,1000,Computer Occupations,111,Release Manager,15.111
 1014,15,1000,Computer Occupations,113,VMware Engineer,15.113
 1015,15,2000,Mathematical Science Occupations,114,Supply Chain Analyst,15.114
@@ -1020,7 +1020,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1018,15,1000,Computer Occupations,117,Linux Administrator,15.117
 1019,15,1000,Computer Occupations,118,Senior Java Software Engineer,15.118
 1020,15,2000,Mathematical Science Occupations,119,Research Analyst (Computer and Mathematical),15.119
-1021,15,1000,Computer Occupations,120,Telecommunications Engineer (Computer and Mathematical),15.120
+1021,15,1000,Computer Occupations,120,Telecommunications Engineer (Computer and Mathematical),15.12
 1022,15,1000,Computer Occupations,121,Cognos Developer,15.121
 1023,15,1000,Computer Occupations,122,Technology Consultant,15.122
 1024,15,1000,Computer Occupations,123,ColdFusion Developer,15.123
@@ -1030,7 +1030,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1028,15,1000,Computer Occupations,127,MicroStrategy Developer,15.127
 1029,15,1000,Computer Occupations,128,Java Architect,15.128
 1030,15,1000,Computer Occupations,129,Data Conversion Developer,15.129
-1031,15,1000,Computer Occupations,130,Business Systems Consultant,15.130
+1031,15,1000,Computer Occupations,130,Business Systems Consultant,15.13
 1032,15,1000,Computer Occupations,131,Microsoft Exchange Engineer,15.131
 1033,15,1000,Computer Occupations,132,Interaction Designer,15.132
 1034,15,1000,Computer Occupations,133,Medical Device Integration Analyst,15.133
@@ -1039,7 +1039,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1037,15,1000,Computer Occupations,137,Help Desk Technician,15.137
 1038,15,1000,Computer Occupations,138,SAS Developer,15.138
 1039,15,1000,Computer Occupations,139,Operations Technician (Computer and Mathematical),15.139
-1040,15,1000,Computer Occupations,140,HRIS Analyst,15.140
+1040,15,1000,Computer Occupations,140,HRIS Analyst,15.14
 1041,15,1000,Computer Occupations,141,Messaging Engineer,15.141
 1042,15,1000,Computer Occupations,142,Business Objects Developer,15.142
 1043,15,1000,Computer Occupations,143,Mainframe Developer,15.143
@@ -1048,7 +1048,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1046,15,1000,Computer Occupations,146,Information Specialist,15.146
 1047,15,1000,Computer Occupations,148,Firewall Engineer,15.148
 1048,15,1000,Computer Occupations,149,Technical Support Representative,15.149
-1049,15,1000,Computer Occupations,150,Integration Developer,15.150
+1049,15,1000,Computer Occupations,150,Integration Developer,15.15
 1050,15,1000,Computer Occupations,151,SAP Developer,15.151
 1051,15,1000,Computer Occupations,152,SharePoint Architect,15.152
 1052,15,1000,Computer Occupations,153,Implementation Engineer,15.153
@@ -1058,7 +1058,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1056,15,1000,Computer Occupations,157,Information Security Specialist,15.157
 1057,15,1000,Computer Occupations,158,Infrastructure Architect,15.158
 1058,15,1000,Computer Occupations,159,Delivery Manager,15.159
-1059,15,1000,Computer Occupations,160,Information Assurance Analyst,15.160
+1059,15,1000,Computer Occupations,160,Information Assurance Analyst,15.16
 1060,15,1000,Computer Occupations,162,Information Assurance Engineer,15.162
 1061,15,1000,Computer Occupations,163,Microsoft Exchange Administrator,15.163
 1062,15,1000,Computer Occupations,164,Sybase Developer,15.164
@@ -1067,7 +1067,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1065,15,1000,Computer Occupations,167,Microsoft Dynamics Developer,15.167
 1066,15,1000,Computer Occupations,168,Senior Technician (Computer and Mathematical),15.168
 1067,15,1000,Computer Occupations,169,Hyperion Planning Support Lead,15.169
-1068,15,1000,Computer Occupations,170,Oracle SCM Planning Subject Matter Expert,15.170
+1068,15,1000,Computer Occupations,170,Oracle SCM Planning Subject Matter Expert,15.17
 1069,15,1000,Computer Occupations,171,Cobol Developer,15.171
 1070,15,1000,Computer Occupations,172,SSRS Developer,15.172
 1071,15,1000,Computer Occupations,173,Lotus Notes DevOps Engineer,15.173
@@ -1076,7 +1076,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1074,15,1000,Computer Occupations,177,Active Directory Engineer,15.177
 1075,15,1000,Computer Occupations,178,JavaScript Developer,15.178
 1076,15,1000,Computer Occupations,179,Configuration Manager,15.179
-1077,15,1000,Computer Occupations,180,Citrix Administrator,15.180
+1077,15,1000,Computer Occupations,180,Citrix Administrator,15.18
 1078,15,1000,Computer Occupations,181,AIX Administrator,15.181
 1079,15,1000,Computer Occupations,182,Content Developer,15.182
 1080,15,1000,Computer Occupations,183,Portal Developer,15.183
@@ -1086,7 +1086,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1084,15,1000,Computer Occupations,187,.Net Architect,15.187
 1085,15,1000,Computer Occupations,188,SAN Administrator,15.188
 1086,15,1000,Computer Occupations,189,Perl Developer,15.189
-1087,15,1000,Computer Occupations,190,Server Engineer,15.190
+1087,15,1000,Computer Occupations,190,Server Engineer,15.19
 1088,15,1000,Computer Occupations,191,Deployment Engineer,15.191
 1089,15,1000,Computer Occupations,192,Hadoop DevOps Engineer,15.192
 1090,15,1000,Computer Occupations,193,Performance Tester,15.193
@@ -1104,7 +1104,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1102,15,1000,Computer Occupations,207,Middleware Engineer,15.207
 1103,15,1000,Computer Occupations,208,Windows Engineer,15.208
 1104,15,1000,Computer Occupations,209,Software Support Technician,15.209
-1105,15,1000,Computer Occupations,210,Lead SAP Consultant,15.210
+1105,15,1000,Computer Occupations,210,Lead SAP Consultant,15.21
 1106,15,1000,Computer Occupations,211,Web Specialist,15.211
 1107,15,1000,Computer Occupations,212,SAP Application Analyst,15.212
 1108,15,1000,Computer Occupations,213,Logistics Analyst (Computer and Mathematical),15.213
@@ -1123,7 +1123,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1121,15,1000,Computer Occupations,227,Solutions Manager,15.227
 1122,15,1000,Computer Occupations,228,Network Designer,15.228
 1123,15,1000,Computer Occupations,229,Analytics Manager (Computer and Mathematical),15.229
-1124,15,1000,Computer Occupations,230,Infrastructure Analyst,15.230
+1124,15,1000,Computer Occupations,230,Infrastructure Analyst,15.23
 1125,15,1000,Computer Occupations,231,Oracle Consultant,15.231
 1126,15,1000,Computer Occupations,232,Application Consultant,15.232
 1127,15,1000,Computer Occupations,233,Implementation Specialist,15.233
@@ -1141,14 +1141,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1139,15,1000,Computer Occupations,247,Build Engineer,15.247
 1140,15,1000,Computer Occupations,248,Information Technology (IT) Support Administrator,15.248
 1141,15,1000,Computer Occupations,249,Integration Engineer (Computer and Mathematical),15.249
-1142,15,1000,Computer Occupations,250,Business Intelligence Analyst,15.250
+1142,15,1000,Computer Occupations,250,Business Intelligence Analyst,15.25
 1143,15,1000,Computer Occupations,253,Data Manager,15.253
 1144,15,1000,Computer Occupations,254,Systems Developer,15.254
 1145,15,1000,Computer Occupations,255,Mobile Software Engineer,15.255
 1146,15,1000,Computer Occupations,257,Operations Engineer (Computer and Mathematical),15.257
 1147,15,1000,Computer Occupations,258,Technologist,15.258
 1148,15,1000,Computer Occupations,259,Design Analyst,15.259
-1149,15,1000,Computer Occupations,260,Forensics Engineer,15.260
+1149,15,1000,Computer Occupations,260,Forensics Engineer,15.26
 1150,15,1000,Computer Occupations,261,Applications Analyst,15.261
 1151,15,1000,Computer Occupations,262,Linux Engineer,15.262
 1152,15,1000,Computer Occupations,263,Systems Integrator,15.263
@@ -1158,7 +1158,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1156,15,1000,Computer Occupations,267,Web Manager,15.267
 1157,15,1000,Computer Occupations,268,Matlab Engineer,15.268
 1158,15,1000,Computer Occupations,269,QTP Automation Engineer,15.269
-1159,15,1000,Computer Occupations,270,Lead Information Security Engineer,15.270
+1159,15,1000,Computer Occupations,270,Lead Information Security Engineer,15.27
 1160,15,1000,Computer Occupations,271,Solutions Analyst,15.271
 1161,15,1000,Computer Occupations,272,Requirements Management Analyst,15.272
 1162,15,1000,Computer Occupations,273,VMware Administrator,15.273
@@ -1175,7 +1175,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1173,15,1000,Computer Occupations,287,Security Manager (Computer and Mathematical),15.287
 1174,15,1000,Computer Occupations,288,Project Analyst (Computer and Mathematical),15.288
 1175,15,1000,Computer Occupations,289,Data Engineer,15.289
-1176,15,1000,Computer Occupations,290,Web Services Engineer,15.290
+1176,15,1000,Computer Occupations,290,Web Services Engineer,15.29
 1177,15,1000,Computer Occupations,291,Data Warehouse Lead,15.291
 1178,15,1000,Computer Occupations,292,Software Analyst,15.292
 1179,15,1000,Computer Occupations,293,PeopleSoft Analyst,15.293
@@ -1191,24 +1191,24 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1189,15,1000,Computer Occupations,306,SharePoint Analyst,15.306
 1190,15,1000,Computer Occupations,307,Business Intelligence Consultant,15.307
 1191,15,1000,Computer Occupations,308,Remote Developer,15.308
-1192,15,1000,Computer Occupations,310,Data Integrator,15.310
+1192,15,1000,Computer Occupations,310,Data Integrator,15.31
 1193,15,1000,Computer Occupations,313,Business Systems Support Analyst,15.313
 1194,15,1000,Computer Occupations,314,Senior Business Intelligence Engineer,15.314
 1195,15,1000,Computer Occupations,315,SAP Architect,15.315
 1196,15,1000,Computer Occupations,316,Solutions Designer,15.316
 1197,15,1000,Computer Occupations,317,Oracle Engineer,15.317
-1198,15,2000,Mathematical Science Occupations,920,Other Topics,15.920
+1198,15,2000,Mathematical Science Occupations,920,Other Topics,15.92
 1199,15,1000,Computer Occupations,10747,Webmaster,15.10747
 1200,15,1000,Computer Occupations,31217,Service-Oriented Architecture (SOA) Architect,15.31217
 1201,15,1000,Computer Occupations,31184,Picture Archiving and Communication System (PACS) Administrator,15.31184
 1202,15,1000,Computer Occupations,31218,Local Area Network (LAN) Administrator,15.31218
 1203,15,1000,Computer Occupations,30922,Advanced Business Application Programming (ABAP) Developer,15.30922
 1204,15,1000,Computer Occupations,10812,Website Designer,15.10812
-1205,15,1000,Computer Occupations,31200,Testing Consultant,15.31200
+1205,15,1000,Computer Occupations,31200,Testing Consultant,15.312
 1206,15,1000,Computer Occupations,10191,Technology Analyst,15.10191
 1207,15,1000,Computer Occupations,30961,Technical Support Manager,15.30961
 1208,15,1000,Computer Occupations,31464,Systems Software Developer,15.31464
-1209,15,1000,Computer Occupations,10320,Systems Designer,15.10320
+1209,15,1000,Computer Occupations,10320,Systems Designer,15.1032
 1210,15,2000,Mathematical Science Occupations,10186,Systems Consultant,15.10186
 1211,15,1000,Computer Occupations,31344,Support Services Technician,15.31344
 1212,15,1000,Computer Occupations,30858,Statistical Programmer,15.30858
@@ -1240,24 +1240,24 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1238,15,2000,Mathematical Science Occupations,10929,Actuary Director,15.10929
 1239,15,2000,Mathematical Science Occupations,10417,Actuarial Consultant,15.10417
 1240,15,1000,Computer Occupations,30016,Information Technology (IT) Systems Analyst,15.30016
-1241,15,1000,Computer Occupations,31190,Windows Server Administrator,15.31190
+1241,15,1000,Computer Occupations,31190,Windows Server Administrator,15.3119
 1242,15,1000,Computer Occupations,11668,Web Analyst,15.11668
 1243,15,1000,Computer Occupations,31233,Staff Software Developer,15.31233
 1244,15,1000,Computer Occupations,30768,Software Development Leader,15.30768
 1245,15,1000,Computer Occupations,10448,Software Designer,15.10448
 1246,15,1000,Computer Occupations,31592,Security Software Developer,15.31592
-1247,15,1000,Computer Occupations,30350,Security Architect,15.30350
-1248,15,1000,Computer Occupations,30550,SAS Programmer,15.30550
+1247,15,1000,Computer Occupations,30350,Security Architect,15.3035
+1248,15,1000,Computer Occupations,30550,SAS Programmer,15.3055
 1249,15,1000,Computer Occupations,11703,Integration Consultant,15.11703
-1250,15,1000,Computer Occupations,11250,Information Analyst (Computer and Mathematical),15.11250
+1250,15,1000,Computer Occupations,11250,Information Analyst (Computer and Mathematical),15.1125
 1251,15,1000,Computer Occupations,31557,Game Engineer,15.31557
 1252,15,1000,Computer Occupations,10546,Epic Consultant,15.10546
-1253,15,1000,Computer Occupations,30650,Data Scientist,15.30650
-1254,15,1000,Computer Occupations,10350,Cyber Analyst,15.10350
+1253,15,1000,Computer Occupations,30650,Data Scientist,15.3065
+1254,15,1000,Computer Occupations,10350,Cyber Analyst,15.1035
 1255,15,1000,Computer Occupations,30568,Systems Coordinator,15.30568
 1256,15,1000,Computer Occupations,30066,Support Engineer (Computer and Mathematical),15.30066
 1257,15,1000,Computer Occupations,11178,Software Administrator,15.11178
-1258,15,1000,Computer Occupations,30030,Programmer Analyst,15.30030
+1258,15,1000,Computer Occupations,30030,Programmer Analyst,15.3003
 1259,15,1000,Computer Occupations,30429,Information Security Engineer,15.30429
 1260,15,1000,Computer Occupations,31268,Game Designer,15.31268
 1261,15,1000,Computer Occupations,30529,Computer Scientist,15.30529
@@ -1268,20 +1268,20 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1266,15,1000,Computer Occupations,30786,Informatics Analyst,15.30786
 1267,15,1000,Computer Occupations,31032,Cyber Security Engineer,15.31032
 1268,15,1000,Computer Occupations,30965,Epic Application Analyst,15.30965
-1269,15,1000,Computer Occupations,30890,Clinical Applications Analyst,15.30890
+1269,15,1000,Computer Occupations,30890,Clinical Applications Analyst,15.3089
 1270,15,1000,Computer Occupations,30323,Quality Assurance (QA) Tester (Computer and Mathematical),15.30323
 1271,15,1000,Computer Occupations,30771,Quality Assurance (QA) Technician (Computer and Mathematical),15.30771
 1272,15,1000,Computer Occupations,11225,Quality Assurance (QA) Coordinator (Computer and Mathematical),15.11225
 1273,15,1000,Computer Occupations,11017,Web Director (Computer and Mathematical),15.11017
 1274,15,1000,Computer Occupations,31285,Telecommunications Manager (Computer and Mathematical),15.31285
-1275,15,1000,Computer Occupations,30460,Technician Supervisor (Computer and Mathematical),15.30460
+1275,15,1000,Computer Occupations,30460,Technician Supervisor (Computer and Mathematical),15.3046
 1276,15,1000,Computer Occupations,30979,Systems Trainer (Computer and Mathematical),15.30979
 1277,15,1000,Computer Occupations,10383,Systems Operator (Computer and Mathematical),15.10383
 1278,15,1000,Computer Occupations,30181,Support Administrator (Computer and Mathematical),15.30181
 1279,15,2000,Mathematical Science Occupations,10784,Statistical Analyst (Computer and Mathematical),15.10784
 1280,15,1000,Computer Occupations,30194,Solutions Consultant (Computer and Mathematical),15.30194
 1281,15,1000,Computer Occupations,10242,Software Development Manager (Computer and Mathematical),15.10242
-1282,15,1000,Computer Occupations,31100,Process Improvement Analyst (Computer and Mathematical),15.31100
+1282,15,1000,Computer Occupations,31100,Process Improvement Analyst (Computer and Mathematical),15.311
 1283,15,1000,Computer Occupations,31029,Optimization Analyst (Computer and Mathematical),15.31029
 1284,15,1000,Computer Occupations,10235,Operations Administrator (Computer and Mathematical),15.10235
 1285,15,1000,Computer Occupations,11307,Monitoring Analyst (Computer and Mathematical),15.11307
@@ -1317,14 +1317,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1315,15,1000,Computer Occupations,1014,Systems Manager (Computer and Mathematical),15.1014
 1316,15,1000,Computer Occupations,1111,Solutions Developer,15.1111
 1317,15,1000,Computer Occupations,1333,SAP Lead,15.1333
-1318,15,1000,Computer Occupations,1220,Junior Developer,15.1220
+1318,15,1000,Computer Occupations,1220,Junior Developer,15.122
 1319,15,1000,Computer Occupations,1343,Director of Software Development,15.1343
 1320,15,1000,Computer Occupations,1059,Support Consultant,15.1059
-1321,15,1000,Computer Occupations,1050,Technology Specialist,15.1050
+1321,15,1000,Computer Occupations,1050,Technology Specialist,15.105
 1322,15,1000,Computer Occupations,1301,Contract Developer,15.1301
 1323,15,1000,Computer Occupations,1208,Geographic Information Systems (GIS) Analyst,15.1208
 1324,15,1000,Computer Occupations,1163,Computer Analyst,15.1163
-1325,15,1000,Computer Occupations,1330,Graphic Designer (Computer and Mathematical),15.1330
+1325,15,1000,Computer Occupations,1330,Graphic Designer (Computer and Mathematical),15.133
 1326,15,1000,Computer Occupations,1003,Software Developer,15.1003
 1327,15,1000,Computer Occupations,1135,Infrastructure Specialist,15.1135
 1328,15,1000,Computer Occupations,1179,Technical Administrator,15.1179
@@ -1342,11 +1342,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1340,15,1000,Computer Occupations,1126,Design Specialist,15.1126
 1341,15,1000,Computer Occupations,1196,Information Developer,15.1196
 1342,15,1000,Computer Occupations,1332,Solutions Lead,15.1332
-1343,15,1000,Computer Occupations,1320,Applications Administrator,15.1320
+1343,15,1000,Computer Occupations,1320,Applications Administrator,15.132
 1344,15,1000,Computer Occupations,1178,Integration Analyst,15.1178
 1345,15,1000,Computer Occupations,1071,Computer Consultant,15.1071
 1346,15,1000,Computer Occupations,1304,Security Lead,15.1304
-1347,15,1000,Computer Occupations,1060,Design Manager (Computer and Mathematical),15.1060
+1347,15,1000,Computer Occupations,1060,Design Manager (Computer and Mathematical),15.106
 1348,15,1000,Computer Occupations,1027,Senior Developer,15.1027
 1349,15,1000,Computer Occupations,1116,Quality Assurance (QA) Lead,15.1116
 1350,15,1000,Computer Occupations,1073,Data Specialist,15.1073
@@ -1357,7 +1357,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1355,15,1000,Computer Occupations,1081,Solution Designer,15.1081
 1356,15,1000,Computer Occupations,1336,Software Team Lead,15.1336
 1357,15,1000,Computer Occupations,1331,Quality Lead (Computer and Mathematical),15.1331
-1358,15,1000,Computer Occupations,1260,Director of Technology (Computer and Mathematical),15.1260
+1358,15,1000,Computer Occupations,1260,Director of Technology (Computer and Mathematical),15.126
 1359,15,1000,Computer Occupations,1104,Integration Specialist,15.1104
 1360,15,1000,Computer Occupations,1037,Applications Engineer,15.1037
 1361,15,1000,Computer Occupations,1067,Senior Programmer,15.1067
@@ -1369,7 +1369,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1367,15,1000,Computer Occupations,1022,Technical Specialist,15.1022
 1368,15,1000,Computer Occupations,1112,Project Specialist (Computer and Mathematical),15.1112
 1369,15,1000,Computer Occupations,1061,Technology Manager (Computer and Mathematical),15.1061
-1370,17,2000,Engineers,0,Quality Assurance (QA) Engineer (Architecture and Engineering),17.0
+1370,17,2000,Engineers,0,Quality Assurance (QA) Engineer (Architecture and Engineering),17
 1371,17,2000,Engineers,1,Mechanical Engineer,17.1
 1372,17,2000,Engineers,2,Project Engineer (Architecture and Engineering),17.2
 1373,17,2000,Engineers,3,Controls Engineer,17.3
@@ -1379,14 +1379,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1377,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",7,Engineering Technician (Architecture and Engineering),17.7
 1378,17,2000,Engineers,8,Process Engineer,17.8
 1379,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",9,Electronics Technician,17.9
-1380,17,2000,Engineers,10,Structural Engineer,17.10
+1380,17,2000,Engineers,10,Structural Engineer,17.1
 1381,17,2000,Engineers,12,Industrial Engineer,17.12
 1382,17,2000,Engineers,14,Civil Engineer,17.14
 1383,17,2000,Engineers,16,Electronics Engineer,17.16
 1384,17,2000,Engineers,17,Safety Manager (Architecture and Engineering),17.17
 1385,17,2000,Engineers,18,Hardware Engineer (Architecture and Engineering),17.18
 1386,17,2000,Engineers,19,Senior Electrical Engineer,17.19
-1387,17,2000,Engineers,20,Radio Frequency Engineer,17.20
+1387,17,2000,Engineers,20,Radio Frequency Engineer,17.2
 1388,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",21,Manufacturing Technician (Architecture and Engineering),17.21
 1389,17,2000,Engineers,22,Packaging Engineer,17.22
 1390,17,2000,Engineers,23,Reliability Engineer,17.23
@@ -1396,7 +1396,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1394,17,2000,Engineers,27,Environmental Engineer,17.27
 1395,17,2000,Engineers,28,Chemical Engineer,17.28
 1396,17,2000,Engineers,29,Senior Manufacturing Engineer,17.29
-1397,17,2000,Engineers,30,Plant Engineer,17.30
+1397,17,2000,Engineers,30,Plant Engineer,17.3
 1398,17,2000,Engineers,31,Safety Engineer,17.31
 1399,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",32,Process Technician (Architecture and Engineering),17.32
 1400,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",34,Electro-Mechanical Technician,17.34
@@ -1405,7 +1405,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1403,17,2000,Engineers,37,Tooling Engineer,17.37
 1404,17,2000,Engineers,38,Aerospace Engineer,17.38
 1405,17,2000,Engineers,39,Quality Control Specialist (Architecture and Engineering),17.39
-1406,17,2000,Engineers,40,Materials Engineer,17.40
+1406,17,2000,Engineers,40,Materials Engineer,17.4
 1407,17,2000,Engineers,41,Operations Engineer (Architecture and Engineering),17.41
 1408,17,2000,Engineers,42,Equipment Engineer,17.42
 1409,17,2000,Engineers,43,Welding Engineer,17.43
@@ -1415,7 +1415,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1413,17,2000,Engineers,47,Safety Coordinator (Architecture and Engineering),17.47
 1414,17,2000,Engineers,48,Pipeline Engineer,17.48
 1415,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",49,Production Technician,17.49
-1416,17,2000,Engineers,50,Instrumentation Engineer,17.50
+1416,17,2000,Engineers,50,Instrumentation Engineer,17.5
 1417,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",51,Field Technician (Architecture and Engineering),17.51
 1418,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",53,Calibration Technician,17.53
 1419,17,2000,Engineers,54,Planning Engineer,17.54
@@ -1439,7 +1439,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1437,17,2000,Engineers,76,Research Engineer (Architecture and Engineering),17.76
 1438,17,2000,Engineers,78,Cost Engineer,17.78
 1439,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",79,Engineering Assistant,17.79
-1440,17,2000,Engineers,80,MRB Engineer,17.80
+1440,17,2000,Engineers,80,MRB Engineer,17.8
 1441,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",81,Architect,17.81
 1442,17,2000,Engineers,82,Transportation Engineer,17.82
 1443,17,2000,Engineers,83,Continuous Improvement Engineer,17.83
@@ -1448,7 +1448,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1446,17,2000,Engineers,87,Water Resource Engineer,17.87
 1447,17,2000,Engineers,88,Injection Molding Process Engineer,17.88
 1448,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",89,Systems Technician (Architecture and Engineering),17.89
-1449,17,2000,Engineers,90,Lead Electrical Engineer,17.90
+1449,17,2000,Engineers,90,Lead Electrical Engineer,17.9
 1450,17,2000,Engineers,93,Marine Engineer,17.93
 1451,17,2000,Engineers,94,Stress Analyst,17.94
 1452,17,2000,Engineers,95,Performance Engineer (Architecture and Engineering),17.95
@@ -1464,7 +1464,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1462,17,2000,Engineers,107,Wireless Engineer (Architecture and Engineering),17.107
 1463,17,2000,Engineers,108,Electrical Test Engineer,17.108
 1464,17,2000,Engineers,109,Metrology Engineer,17.109
-1465,17,2000,Engineers,110,Nuclear Engineer,17.110
+1465,17,2000,Engineers,110,Nuclear Engineer,17.11
 1466,17,2000,Engineers,111,OSP Engineer,17.111
 1467,17,2000,Engineers,112,Safety Supervisor,17.112
 1468,17,2000,Engineers,113,RAN Engineer,17.113
@@ -1473,7 +1473,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1471,17,2000,Engineers,116,Technical Manager (Architecture and Engineering),17.116
 1472,17,2000,Engineers,117,Certification Engineer,17.117
 1473,17,2000,Engineers,119,PLC Engineer,17.119
-1474,17,2000,Engineers,120,Reservoir Engineer,17.120
+1474,17,2000,Engineers,120,Reservoir Engineer,17.12
 1475,17,2000,Engineers,121,Design Engineer (Architecture and Engineering),17.121
 1476,17,2000,Engineers,122,Lean Manufacturing Engineer,17.122
 1477,17,2000,Engineers,123,Sustaining Engineer,17.123
@@ -1483,14 +1483,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1481,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",127,PLC Technician,17.127
 1482,17,2000,Engineers,128,Technical Services Engineer,17.128
 1483,17,2000,Engineers,129,Transmission Engineer,17.129
-1484,17,2000,Engineers,130,Drilling Engineer,17.130
+1484,17,2000,Engineers,130,Drilling Engineer,17.13
 1485,17,2000,Engineers,134,Electrical Engineer,17.134
 1486,17,2000,Engineers,135,SCADA Engineer,17.135
 1487,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",136,Engineering Technologist,17.136
 1488,17,2000,Engineers,137,Resident Engineer,17.137
 1489,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",138,NDT Technician,17.138
 1490,17,2000,Engineers,139,Project Coordinator (Architecture and Engineering),17.139
-1491,17,1000,"Architects, Surveyors, and Cartographers",140,Planner (Architecture and Engineering),17.140
+1491,17,1000,"Architects, Surveyors, and Cartographers",140,Planner (Architecture and Engineering),17.14
 1492,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",141,Manufacturing Specialist,17.141
 1493,17,2000,Engineers,143,NDT Inspector,17.143
 1494,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",144,Project Leader (Architecture and Engineering),17.144
@@ -1507,7 +1507,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1505,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",157,Packaging Technician,17.157
 1506,17,2000,Engineers,158,Logistics Engineer (Architecture and Engineering),17.158
 1507,17,2000,Engineers,159,Installation Engineer,17.159
-1508,17,2000,Engineers,160,Wiring Engineer,17.160
+1508,17,2000,Engineers,160,Wiring Engineer,17.16
 1509,17,2000,Engineers,161,Seating Engineer,17.161
 1510,17,2000,Engineers,162,Safety Director (Architecture and Engineering),17.162
 1511,17,2000,Engineers,163,Process Improvement Manager,17.163
@@ -1517,17 +1517,17 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1515,17,2000,Engineers,167,Project Manager (Architecture and Engineering),17.167
 1516,17,2000,Engineers,168,Sheet Metal Engineer,17.168
 1517,17,2000,Engineers,169,Power Systems Engineer,17.169
-1518,17,2000,Engineers,170,Energy Engineer,17.170
+1518,17,2000,Engineers,170,Energy Engineer,17.17
 1519,17,2000,Engineers,175,Metallurgist,17.175
 1520,17,2000,Engineers,176,Solar Engineer,17.176
 1521,17,2000,Engineers,178,Water and Wastewater Manager,17.178
 1522,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",179,Industrial Engineering Technician,17.179
-1523,17,2000,Engineers,180,Electrical Controls Programmer,17.180
+1523,17,2000,Engineers,180,Electrical Controls Programmer,17.18
 1524,17,2000,Engineers,181,Composite Engineer,17.181
 1525,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",184,Maintenance Technician (Architecture and Engineering),17.184
 1526,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",187,Environmental Specialist (Architecture and Engineering),17.187
 1527,17,2000,Engineers,188,OBD Engineer,17.188
-1528,17,2000,Engineers,190,Automotive Body Engineer,17.190
+1528,17,2000,Engineers,190,Automotive Body Engineer,17.19
 1529,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",191,Avionics Technician (Architecture and Engineering),17.191
 1530,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",194,Drafter,17.194
 1531,17,2000,Engineers,195,Analog Engineer,17.195
@@ -1560,7 +1560,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1558,17,2000,Engineers,30442,Seismic Engineer,17.30442
 1559,17,2000,Engineers,31082,Project Controls Engineer,17.31082
 1560,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30107,Mechanical Technician (Architecture and Engineering),17.30107
-1561,17,2000,Engineers,31290,Manufacturing Planner,17.31290
+1561,17,2000,Engineers,31290,Manufacturing Planner,17.3129
 1562,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",10455,Imagery Analyst,17.10455
 1563,17,2000,Engineers,31326,Fire Engineer (Architecture and Engineering),17.31326
 1564,17,2000,Engineers,31179,Escalation Engineer,17.31179
@@ -1579,11 +1579,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1577,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",31272,Controls Designer,17.31272
 1578,17,2000,Engineers,31359,Engineer Scientist,17.31359
 1579,17,2000,Engineers,30771,Quality Assurance (QA) Technician (Architecture and Engineering),17.30771
-1580,17,2000,Engineers,30880,"Environmental, Health, and Safety (EHS) Manager (Architecture and Engineering)",17.30880
-1581,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",10780,Transportation Technician (Architecture and Engineering),17.10780
-1582,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30460,Technician Supervisor (Architecture and Engineering),17.30460
-1583,17,2000,Engineers,30570,Piping Designer (Architecture and Engineering),17.30570
-1584,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30990,Layout Designer (Architecture and Engineering),17.30990
+1580,17,2000,Engineers,30880,"Environmental, Health, and Safety (EHS) Manager (Architecture and Engineering)",17.3088
+1581,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",10780,Transportation Technician (Architecture and Engineering),17.1078
+1582,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30460,Technician Supervisor (Architecture and Engineering),17.3046
+1583,17,2000,Engineers,30570,Piping Designer (Architecture and Engineering),17.3057
+1584,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30990,Layout Designer (Architecture and Engineering),17.3099
 1585,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30837,Independent Contractor (Architecture and Engineering),17.30837
 1586,17,2000,Engineers,31415,Imaging Engineer (Architecture and Engineering),17.31415
 1587,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",30293,Environmental Services Technician (Architecture and Engineering),17.30293
@@ -1602,8 +1602,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1600,17,1000,"Architects, Surveyors, and Cartographers",1213,Building Consultant,17.1213
 1601,17,2000,Engineers,1347,Piping Engineer,17.1347
 1602,17,2000,Engineers,1353,Radio Engineer,17.1353
-1603,17,2000,Engineers,1260,Analog Design Engineer,17.1260
-1604,17,2000,Engineers,1150,Environmental Consultant (Architecture and Engineering),17.1150
+1603,17,2000,Engineers,1260,Analog Design Engineer,17.126
+1604,17,2000,Engineers,1150,Environmental Consultant (Architecture and Engineering),17.115
 1605,17,2000,Engineers,1058,Engineering Officer,17.1058
 1606,17,2000,Engineers,1146,Urban Designer,17.1146
 1607,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1105,Technical Designer (Architecture and Engineering),17.1105
@@ -1616,7 +1616,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1614,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1079,Architectural Assistant,17.1079
 1615,17,2000,Engineers,1268,B1 Licensed Engineer,17.1268
 1616,17,2000,Engineers,1222,Drilling Consultant,17.1222
-1617,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1360,Manufacturing Designer,17.1360
+1617,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1360,Manufacturing Designer,17.136
 1618,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1153,Quality Technician (Architecture and Engineering),17.1153
 1619,17,2000,Engineers,1316,Outside Plant (OSP) Engineer,17.1316
 1620,17,2000,Engineers,1336,Principal Designer,17.1336
@@ -1637,19 +1637,19 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1635,17,2000,Engineers,1251,Oil and Gas Consultant,17.1251
 1636,17,2000,Engineers,1166,Communication System Engineer,17.1166
 1637,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1078,Computer Aided Design (CAD) Designer (Architecture and Engineering),17.1078
-1638,17,2000,Engineers,1280,Lead Engineer (Architecture and Engineering),17.1280
+1638,17,2000,Engineers,1280,Lead Engineer (Architecture and Engineering),17.128
 1639,17,2000,Engineers,1036,Chief Engineer (Architecture and Engineering),17.1036
 1640,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1319,Engineering Intern,17.1319
 1641,17,2000,Engineers,1091,Traffic Engineer,17.1091
 1642,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1205,Building Designer,17.1205
-1643,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1010,Draftsperson (Architecture and Engineering),17.1010
+1643,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1010,Draftsperson (Architecture and Engineering),17.101
 1644,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1132,Architectural Technician,17.1132
 1645,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1217,Instrumentation Specialist,17.1217
 1646,17,2000,Engineers,1226,Systems Test Engineer,17.1226
 1647,17,2000,Engineers,1177,Head Engineer,17.1177
 1648,17,2000,Engineers,1354,Regional Engineer,17.1354
 1649,17,2000,Engineers,1026,Aircraft Engineer,17.1026
-1650,17,2000,Engineers,1170,Chief Designer,17.1170
+1650,17,2000,Engineers,1170,Chief Designer,17.117
 1651,17,2000,Engineers,1082,Asset Engineer,17.1082
 1652,17,2000,Engineers,1269,Application Specific Integrated Circuit (ASIC) Engineer,17.1269
 1653,17,2000,Engineers,1191,Inspection Engineer,17.1191
@@ -1659,9 +1659,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1657,17,2000,Engineers,1019,Support Engineer (Architecture and Engineering),17.1019
 1658,17,2000,Engineers,1126,Professional Engineer,17.1126
 1659,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1164,Instrument Designer,17.1164
-1660,17,2000,Engineers,1240,Network Engineer (Architecture and Engineering),17.1240
+1660,17,2000,Engineers,1240,Network Engineer (Architecture and Engineering),17.124
 1661,17,2000,Engineers,1059,Power Engineer,17.1059
-1662,17,2000,Engineers,1350,Offshore Engineer,17.1350
+1662,17,2000,Engineers,1350,Offshore Engineer,17.135
 1663,17,2000,Engineers,1144,Weapons Engineer,17.1144
 1664,17,2000,Engineers,1292,New Product Introduction (NPI) Engineer,17.1292
 1665,17,2000,Engineers,1145,Customer Engineer,17.1145
@@ -1669,19 +1669,19 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1667,17,3000,"Drafters, Engineering Technicians, and Mapping Technicians",1214,Member of Technical Staff (MTS),17.1214
 1668,17,2000,Engineers,1013,Service Engineer,17.1013
 1669,17,2000,Engineers,1008,Principal Engineer,17.1008
-1670,19,4000,"Life, Physical, and Social Science Technicians",0,"Laboratory Technician (Life, Physical, and Social Science)",19.0
+1670,19,4000,"Life, Physical, and Social Science Technicians",0,"Laboratory Technician (Life, Physical, and Social Science)",19
 1671,19,2000,Physical Scientists,1,Chemist,19.1
 1672,19,3000,Social Scientists and Related Workers,2,Social Scientist,19.2
 1673,19,4000,"Life, Physical, and Social Science Technicians",4,"Research Analyst (Life, Physical, and Social Science)",19.4
 1674,19,4000,"Life, Physical, and Social Science Technicians",5,"Field Technician (Life, Physical, and Social Science)",19.5
 1675,19,1000,Life Scientists,7,Clinical Laboratory Scientist,19.7
-1676,19,4000,"Life, Physical, and Social Science Technicians",10,"Research Assistant (Life, Physical, and Social Science)",19.10
+1676,19,4000,"Life, Physical, and Social Science Technicians",10,"Research Assistant (Life, Physical, and Social Science)",19.1
 1677,19,1000,Life Scientists,11,Research Scientist,19.11
 1678,19,4000,"Life, Physical, and Social Science Technicians",13,Environmental Scientist,19.13
 1679,19,4000,"Life, Physical, and Social Science Technicians",16,"Laboratory Assistant (Life, Physical, and Social Science)",19.16
 1680,19,4000,"Life, Physical, and Social Science Technicians",17,Chemical Technician,19.17
 1681,19,4000,"Life, Physical, and Social Science Technicians",18,Quality Control Analyst,19.18
-1682,19,4000,"Life, Physical, and Social Science Technicians",20,Environmental Technician,19.20
+1682,19,4000,"Life, Physical, and Social Science Technicians",20,Environmental Technician,19.2
 1683,19,4000,"Life, Physical, and Social Science Technicians",21,Research Specialist,19.21
 1684,19,4000,"Life, Physical, and Social Science Technicians",23,Research Technician,19.23
 1685,19,4000,"Life, Physical, and Social Science Technicians",24,Laboratory Analyst,19.24
@@ -1698,7 +1698,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1696,19,2000,Physical Scientists,45,Principal Scientist,19.45
 1697,19,2000,Physical Scientists,46,Geologist,19.46
 1698,19,4000,"Life, Physical, and Social Science Technicians",48,Microbiology Technician,19.48
-1699,19,1000,Life Scientists,50,Biologist,19.50
+1699,19,1000,Life Scientists,50,Biologist,19.5
 1700,19,4000,"Life, Physical, and Social Science Technicians",51,Research and Development (R&D) Technician,19.51
 1701,19,1000,Life Scientists,53,Process Development Scientist,19.53
 1702,19,4000,"Life, Physical, and Social Science Technicians",54,Clinical Trials Assistant,19.54
@@ -1708,11 +1708,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1706,19,4000,"Life, Physical, and Social Science Technicians",63,Quality Assurance (QA) Analyst,19.63
 1707,19,4000,"Life, Physical, and Social Science Technicians",67,"Laboratory Supervisor (Life, Physical, and Social Science)",19.67
 1708,19,4000,"Life, Physical, and Social Science Technicians",69,Quality Control Scientist,19.69
-1709,19,4000,"Life, Physical, and Social Science Technicians",70,Gas Technician,19.70
+1709,19,4000,"Life, Physical, and Social Science Technicians",70,Gas Technician,19.7
 1710,19,4000,"Life, Physical, and Social Science Technicians",72,Environmental Assistant,19.72
 1711,19,4000,"Life, Physical, and Social Science Technicians",74,"Operations Technician (Life, Physical, and Social Science)",19.74
 1712,19,1000,Life Scientists,78,Environmental Analyst,19.78
-1713,19,1000,Life Scientists,80,Cell Culture Scientist,19.80
+1713,19,1000,Life Scientists,80,Cell Culture Scientist,19.8
 1714,19,4000,"Life, Physical, and Social Science Technicians",85,Latent Print Technician,19.85
 1715,19,4000,"Life, Physical, and Social Science Technicians",86,Bioprocess Technician,19.86
 1716,19,4000,"Life, Physical, and Social Science Technicians",92,Sample Technician,19.92
@@ -1723,22 +1723,22 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1721,19,4000,"Life, Physical, and Social Science Technicians",107,"Quality Control Specialist (Life, Physical, and Social Science)",19.107
 1722,19,2000,Physical Scientists,108,Materials Scientist,19.108
 1723,19,3000,Social Scientists and Related Workers,109,Transportation Planner,19.109
-1724,19,4000,"Life, Physical, and Social Science Technicians",110,Project Scientist,19.110
+1724,19,4000,"Life, Physical, and Social Science Technicians",110,Project Scientist,19.11
 1725,19,4000,"Life, Physical, and Social Science Technicians",112,Biological Scientist,19.112
 1726,19,2000,Physical Scientists,116,Environmental Protection Specialist,19.116
 1727,19,1000,Life Scientists,117,Validation Scientist,19.117
 1728,19,4000,"Life, Physical, and Social Science Technicians",119,Hazmat Technician,19.119
-1729,19,4000,"Life, Physical, and Social Science Technicians",120,Air Quality Specialist,19.120
+1729,19,4000,"Life, Physical, and Social Science Technicians",120,Air Quality Specialist,19.12
 1730,19,1000,Life Scientists,123,Biochemist,19.123
 1731,19,4000,"Life, Physical, and Social Science Technicians",126,Molecular Biology Research Associate,19.126
-1732,19,4000,"Life, Physical, and Social Science Technicians",130,Corrosion Technician,19.130
+1732,19,4000,"Life, Physical, and Social Science Technicians",130,Corrosion Technician,19.13
 1733,19,1000,Life Scientists,132,Field Specialist,19.132
 1734,19,4000,"Life, Physical, and Social Science Technicians",133,Analytical Technologist,19.133
 1735,19,4000,"Life, Physical, and Social Science Technicians",138,Fermentation Technician,19.138
 1736,19,4000,"Life, Physical, and Social Science Technicians",142,Soils Technician,19.142
 1737,19,4000,"Life, Physical, and Social Science Technicians",144,Technical Assistant,19.144
 1738,19,4000,"Life, Physical, and Social Science Technicians",146,Hazardous Waste Technician,19.146
-1739,19,1000,Life Scientists,150,Method Development Scientist,19.150
+1739,19,1000,Life Scientists,150,Method Development Scientist,19.15
 1740,19,1000,Life Scientists,152,Scientific Analyst,19.152
 1741,19,4000,"Life, Physical, and Social Science Technicians",153,Animal Laboratory Technician,19.153
 1742,19,2000,Physical Scientists,155,Applications Scientist,19.155
@@ -1759,10 +1759,10 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1757,19,4000,"Life, Physical, and Social Science Technicians",192,Water Technician,19.192
 1758,19,2000,Physical Scientists,197,Hydrogeologist,19.197
 1759,19,1000,Life Scientists,198,Toxicologist,19.198
-1760,19,4000,"Life, Physical, and Social Science Technicians",200,Metallurgical Technician,19.200
+1760,19,4000,"Life, Physical, and Social Science Technicians",200,Metallurgical Technician,19.2
 1761,19,4000,"Life, Physical, and Social Science Technicians",202,Forester,19.202
 1762,19,4000,"Life, Physical, and Social Science Technicians",203,Assistant Technician,19.203
-1763,19,1000,Life Scientists,210,Molecular Biology Scientist,19.210
+1763,19,1000,Life Scientists,210,Molecular Biology Scientist,19.21
 1764,19,4000,"Life, Physical, and Social Science Technicians",211,Assistant Analyst,19.211
 1765,19,2000,Physical Scientists,213,Formulation Chemist,19.213
 1766,19,4000,"Life, Physical, and Social Science Technicians",216,Quality Control Laboratory Technician,19.216
@@ -1770,7 +1770,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1768,19,4000,"Life, Physical, and Social Science Technicians",225,Paint Laboratory Technician,19.225
 1769,19,1000,Life Scientists,227,Other Topics,19.227
 1770,19,3000,Social Scientists and Related Workers,30838,Transportation Analyst,19.30838
-1771,19,2000,Physical Scientists,31410,Production Scientist,19.31410
+1771,19,2000,Physical Scientists,31410,Production Scientist,19.3141
 1772,19,1000,Life Scientists,31073,Pharmacologist,19.31073
 1773,19,2000,Physical Scientists,11467,Petrophysicist,19.11467
 1774,19,2000,Physical Scientists,11255,Meteorologist,19.11255
@@ -1783,7 +1783,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1781,19,1000,Life Scientists,30444,Development Scientist,19.30444
 1782,19,4000,"Life, Physical, and Social Science Technicians",30927,"Quality Assurance (QA) Associate (Life, Physical, and Social Science)",19.30927
 1783,19,4000,"Life, Physical, and Social Science Technicians",30735,"Technical Supervisor (Life, Physical, and Social Science)",19.30735
-1784,19,4000,"Life, Physical, and Social Science Technicians",10790,"Specimen Technician (Life, Physical, and Social Science)",19.10790
+1784,19,4000,"Life, Physical, and Social Science Technicians",10790,"Specimen Technician (Life, Physical, and Social Science)",19.1079
 1785,19,4000,"Life, Physical, and Social Science Technicians",10359,"Resource Manager (Life, Physical, and Social Science)",19.10359
 1786,19,3000,Social Scientists and Related Workers,30957,"Research Fellow (Life, Physical, and Social Science)",19.30957
 1787,19,3000,Social Scientists and Related Workers,10388,"Research Coordinator (Life, Physical, and Social Science)",19.10388
@@ -1805,16 +1805,16 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1803,19,1000,Life Scientists,1233,Environmental Coordinator,19.1233
 1804,19,3000,Social Scientists and Related Workers,1151,Research Collaborator,19.1151
 1805,19,1000,Life Scientists,1327,Bioinformatician,19.1327
-1806,19,1000,Life Scientists,1260,Environmental Officer,19.1260
+1806,19,1000,Life Scientists,1260,Environmental Officer,19.126
 1807,19,1000,Life Scientists,1179,Visiting Scientist,19.1179
 1808,19,3000,Social Scientists and Related Workers,1119,"Planning Director (Life, Physical, and Social Science)",19.1119
 1809,19,4000,"Life, Physical, and Social Science Technicians",1087,Quality Analyst,19.1087
 1810,19,1000,Life Scientists,1097,Visiting Researcher,19.1097
 1811,19,1000,Life Scientists,1218,Horticulturist,19.1218
-1812,19,4000,"Life, Physical, and Social Science Technicians",1050,Geoscientist,19.1050
+1812,19,4000,"Life, Physical, and Social Science Technicians",1050,Geoscientist,19.105
 1813,19,3000,Social Scientists and Related Workers,1257,Neuropsychologist,19.1257
 1814,19,1000,Life Scientists,1221,Physiologist,19.1221
-1815,19,3000,Social Scientists and Related Workers,1140,"Licensed Professional Counselor (LPC) (Life, Physical, and Social Science)",19.1140
+1815,19,3000,Social Scientists and Related Workers,1140,"Licensed Professional Counselor (LPC) (Life, Physical, and Social Science)",19.114
 1816,19,1000,Life Scientists,1298,Energy Researcher,19.1298
 1817,19,1000,Life Scientists,1147,Conservationist,19.1147
 1818,19,4000,"Life, Physical, and Social Science Technicians",1187,Conservation Officer,19.1187
@@ -1839,8 +1839,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1837,19,1000,Life Scientists,1068,Naturalist,19.1068
 1838,19,3000,Social Scientists and Related Workers,1252,Anthropologist,19.1252
 1839,19,2000,Physical Scientists,1314,Astronomer,19.1314
-1840,19,1000,Life Scientists,1010,Undergraduate Researcher,19.1010
-1841,19,3000,Social Scientists and Related Workers,1080,Research Director,19.1080
+1840,19,1000,Life Scientists,1010,Undergraduate Researcher,19.101
+1841,19,3000,Social Scientists and Related Workers,1080,Research Director,19.108
 1842,19,3000,Social Scientists and Related Workers,1031,Historian,19.1031
 1843,19,1000,Life Scientists,1242,Project Researcher,19.1242
 1844,19,1000,Life Scientists,1006,Senior Scientist,19.1006
@@ -1849,7 +1849,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1847,19,3000,Social Scientists and Related Workers,1126,Social Researcher,19.1126
 1848,19,1000,Life Scientists,1209,Medical Scientist,19.1209
 1849,19,3000,Social Scientists and Related Workers,2177,Policy Officer,19.2177
-1850,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",0,Residential Support Staff,21.0
+1850,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",0,Residential Support Staff,21
 1851,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1,Admissions Representative (Community and Social Services),21.1
 1852,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",2,Social Worker,21.2
 1853,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",3,Licensed Clinical Social Worker (LCSW),21.3
@@ -1859,7 +1859,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1857,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",7,Case Manager (Community and Social Services),21.7
 1858,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",8,Medical Social Worker,21.8
 1859,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",9,Career Services Representative,21.9
-1860,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",10,Educational Recruiter,21.10
+1860,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",10,Educational Recruiter,21.1
 1861,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",11,Activities Assistant (Community and Social Services),21.11
 1862,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",12,Residential Counselor,21.12
 1863,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",15,Family Counselor,21.15
@@ -1867,7 +1867,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1865,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",17,Lead Residential Support Staff,21.17
 1866,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",18,Social Work Case Manager,21.18
 1867,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",19,Mental Health Counselor,21.19
-1868,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",20,Direct Support Professional (DSP),21.20
+1868,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",20,Direct Support Professional (DSP),21.2
 1869,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",21,Behavior Specialist,21.21
 1870,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",22,Youth Care Worker,21.22
 1871,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",23,Mental Health Therapist,21.23
@@ -1876,7 +1876,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1874,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",27,Career Services Advisor,21.27
 1875,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",28,Mental Health Clinician,21.28
 1876,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",29,Hospice Social Worker,21.29
-1877,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",30,Admissions Counselor,21.30
+1877,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",30,Admissions Counselor,21.3
 1878,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",31,Educational Counselor,21.31
 1879,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",32,Job Coach,21.32
 1880,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",33,Family Support Worker,21.33
@@ -1886,7 +1886,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1884,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",37,Career Services Specialist,21.37
 1885,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",38,Clinical Therapist,21.38
 1886,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",39,Outpatient Therapist,21.39
-1887,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",40,Social Services Assistant,21.40
+1887,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",40,Social Services Assistant,21.4
 1888,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",41,Mental Health Specialist,21.41
 1889,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",42,Behavioral Health Therapist,21.42
 1890,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",43,Mental Health Worker,21.43
@@ -1907,7 +1907,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1905,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",66,Peer Support Specialist,21.66
 1906,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",68,Director of Career Services,21.68
 1907,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",69,Behavioral Health Clinician,21.69
-1908,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",70,Career Transition Specialist,21.70
+1908,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",70,Career Transition Specialist,21.7
 1909,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",72,Enrollment Representative,21.72
 1910,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",73,Licensed Social Worker (LSW),21.73
 1911,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",74,Community Support Staff,21.74
@@ -1915,7 +1915,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1913,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",76,Youth Specialist,21.76
 1914,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",77,Dependency Case Manager,21.77
 1915,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",79,Mental Health Professional,21.79
-1916,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",80,Patient Service Representative (Community and Social Services),21.80
+1916,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",80,Patient Service Representative (Community and Social Services),21.8
 1917,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",81,Residential Supervisor,21.81
 1918,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",82,TEAP Substance Abuse Specialist,21.82
 1919,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",84,Bilingual Counselor,21.84
@@ -1928,7 +1928,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1926,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",92,Clinical Case Manager,21.92
 1927,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",95,Housing Specialist,21.95
 1928,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",99,Psychologist (Community and Social Services),21.99
-1929,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",100,Social Services Specialist,21.100
+1929,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",100,Social Services Specialist,21.1
 1930,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",101,Social Work Supervisor,21.101
 1931,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",102,Care Advocate,21.102
 1932,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",104,Housing Counselor,21.104
@@ -1936,37 +1936,37 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1934,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",106,Family Intervention Specialist,21.106
 1935,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",107,Education Specialist (Community and Social Services),21.107
 1936,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",109,Behavioral Health Counselor,21.109
-1937,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",110,Career Planning Specialist,21.110
+1937,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",110,Career Planning Specialist,21.11
 1938,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",112,Outpatient Clinician,21.112
 1939,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",113,Recovery Resiliency Manager,21.113
 1940,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",117,Assessment Counselor,21.117
 1941,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",118,Qualified Mental Retardation Professional (QMRP),21.118
 1942,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",119,Academic Affairs Specialist,21.119
-1943,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",120,Child Care Worker,21.120
+1943,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",120,Child Care Worker,21.12
 1944,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",124,Intensive In-Home Team Lead,21.124
 1945,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",125,Mobile Therapist,21.125
 1946,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",126,Crisis Counselor,21.126
 1947,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",127,High School Presenter,21.127
 1948,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",128,Life Skills Worker,21.128
 1949,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",129,Enrollment Counselor,21.129
-1950,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",130,Certified Peer Specialist (CPS),21.130
+1950,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",130,Certified Peer Specialist (CPS),21.13
 1951,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",132,Prevention Specialist,21.132
 1952,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",133,Crisis Clinician,21.133
 1953,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",135,Public Health Analyst,21.135
 1954,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",136,Community Health Worker,21.136
 1955,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",138,Probation Officer,21.138
-1956,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",140,Residential Specialist,21.140
+1956,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",140,Residential Specialist,21.14
 1957,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",141,School Social Worker,21.141
 1958,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",142,Crisis Specialist,21.142
 1959,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",143,Substance Abuse Clinician,21.143
 1960,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",147,Referral Specialist,21.147
-1961,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",150,Correctional Counselor,21.150
+1961,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",150,Correctional Counselor,21.15
 1962,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",151,Therapist Case Manager,21.151
 1963,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",152,Behavioral Health Case Manager,21.152
 1964,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",154,Behavioral Intake Counselor,21.154
 1965,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",156,Onsite Health Specialist,21.156
 1966,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",159,Admissions Specialist,21.159
-1967,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",160,Substance Abuse Therapist,21.160
+1967,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",160,Substance Abuse Therapist,21.16
 1968,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",162,Housing Case Manager,21.162
 1969,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",163,Home Visitor,21.163
 1970,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",166,Crisis Worker,21.166
@@ -1974,13 +1974,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1972,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",175,Life Enrichment Assistant (Community and Social Services),21.175
 1973,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",177,Home Care Social Worker,21.177
 1974,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",178,Psychiatric Social Worker,21.178
-1975,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",180,Assessment Specialist,21.180
+1975,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",180,Assessment Specialist,21.18
 1976,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",184,Vocational Specialist,21.184
 1977,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",185,Mental Health Practitioner,21.185
 1978,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",187,Vocational Case Manager,21.187
 1979,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",188,Student Services Representative,21.188
 1980,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",189,Field Case Manager,21.189
-1981,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",190,Community Case Manager,21.190
+1981,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",190,Community Case Manager,21.19
 1982,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",192,Placement Specialist,21.192
 1983,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",194,Lead Clinician,21.194
 1984,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",195,Assessment Clinician,21.195
@@ -1989,26 +1989,26 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 1987,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",202,Student Services Specialist,21.202
 1988,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",207,Substance Abuse Manager,21.207
 1989,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",209,Life Coach,21.209
-1990,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",210,Healthcare Social Worker,21.210
+1990,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",210,Healthcare Social Worker,21.21
 1991,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",215,Social Services Director (Community and Social Services),21.215
 1992,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",217,Bilingual Clinician,21.217
 1993,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",218,Counselor Aide,21.218
 1994,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",219,Inpatient Social Worker,21.219
-1995,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",220,Licensed Master Social Worker (LMSW),21.220
+1995,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",220,Licensed Master Social Worker (LMSW),21.22
 1996,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",223,School Therapist,21.223
 1997,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",226,Counselor Case Manager,21.226
-1998,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",230,Community Support Supervisor,21.230
+1998,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",230,Community Support Supervisor,21.23
 1999,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",233,Intensive In-Home Counselor,21.233
 2000,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",236,Child Therapist,21.236
-2001,21,2000,Religious Workers,240,Pastor,21.240
+2001,21,2000,Religious Workers,240,Pastor,21.24
 2002,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",242,Counselor Therapist,21.242
 2003,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",245,Student Advisor,21.245
-2004,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",250,Adult Therapist,21.250
+2004,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",250,Adult Therapist,21.25
 2005,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",259,Clinical Social Worker,21.259
 2006,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",263,Counselor Outpatient,21.263
 2007,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",271,Other Topics,21.271
-2008,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",11100,Volunteer Coordinator,21.11100
-2009,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",10930,Referral Coordinator,21.10930
+2008,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",11100,Volunteer Coordinator,21.111
+2009,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",10930,Referral Coordinator,21.1093
 2010,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",31467,Health Supervisor (Community and Social Services),21.31467
 2011,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",10821,Field Coordinator,21.10821
 2012,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",30723,Diabetes Educator,21.30723
@@ -2036,7 +2036,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2034,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1241,Certified Alcohol Drug Counselor (CADC),21.1241
 2035,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1099,Youth Educator,21.1099
 2036,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1166,Career Coordinator,21.1166
-2037,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1050,Community Worker,21.1050
+2037,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1050,Community Worker,21.105
 2038,21,2000,Religious Workers,1073,Clergy,21.1073
 2039,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1145,Missions Coordinator,21.1145
 2040,21,2000,Religious Workers,1107,Christian Counselor,21.1107
@@ -2049,7 +2049,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2047,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1203,Social Assistant,21.1203
 2048,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1141,Director of Counseling,21.1141
 2049,21,2000,Religious Workers,1075,Rabbi,21.1075
-2050,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1130,Case Coordinator,21.1130
+2050,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1130,Case Coordinator,21.113
 2051,21,2000,Religious Workers,1063,Faith Formation Director,21.1063
 2052,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1013,Organizer,21.1013
 2053,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1047,Worship Director,21.1047
@@ -2066,7 +2066,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2064,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1121,National Coordinator,21.1121
 2065,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1115,Senior Counselor,21.1115
 2066,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1033,Director of Missions,21.1033
-2067,21,2000,Religious Workers,1030,Evangelist,21.1030
+2067,21,2000,Religious Workers,1030,Evangelist,21.103
 2068,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1165,Family Worker,21.1165
 2069,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1017,Program Assistant (Community and Social Services),21.1017
 2070,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1148,Faith Formation Coordinator,21.1148
@@ -2082,14 +2082,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2080,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1111,Licensed Professional Counselor (LPC) (Community and Social Services),21.1111
 2081,21,2000,Religious Workers,1095,Deacon,21.1095
 2082,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1035,Spiritual Director,21.1035
-2083,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1080,Head Counselor,21.1080
+2083,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1080,Head Counselor,21.108
 2084,21,2000,Religious Workers,1249,Youth Coordinator,21.1249
 2085,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1194,Housing Assistant,21.1194
 2086,21,2000,Religious Workers,1044,Bishop,21.1044
 2087,21,2000,Religious Workers,1001,Minister,21.1001
 2088,21,1000,"Counselors, Social Workers, and Other Community and Social Service Specialists",1011,Ministry Director,21.1011
 2089,21,2000,Religious Workers,1027,Priest,21.1027
-2090,23,2000,Legal Support Workers,0,Legal Assistant (Legal),23.0
+2090,23,2000,Legal Support Workers,0,Legal Assistant (Legal),23
 2091,23,2000,Legal Support Workers,1,Litigation Paralegal,23.1
 2092,23,2000,Legal Support Workers,2,Corporate Paralegal,23.2
 2093,23,2000,Legal Support Workers,3,Real Estate Paralegal,23.3
@@ -2099,7 +2099,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2097,23,1000,"Lawyers, Judges, and Related Workers",7,Contract Attorney,23.7
 2098,23,1000,"Lawyers, Judges, and Related Workers",8,Assistant General Counsel,23.8
 2099,23,1000,"Lawyers, Judges, and Related Workers",9,Corporate Attorney,23.9
-2100,23,2000,Legal Support Workers,10,Contracts Paralegal,23.10
+2100,23,2000,Legal Support Workers,10,Contracts Paralegal,23.1
 2101,23,1000,"Lawyers, Judges, and Related Workers",11,Legal Counsel,23.11
 2102,23,2000,Legal Support Workers,12,Title Processor,23.12
 2103,23,1000,"Lawyers, Judges, and Related Workers",13,Patent Attorney,23.13
@@ -2118,7 +2118,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2116,23,1000,"Lawyers, Judges, and Related Workers",27,Lawyer,23.27
 2117,23,1000,"Lawyers, Judges, and Related Workers",28,Compliance Attorney,23.28
 2118,23,1000,"Lawyers, Judges, and Related Workers",29,Transaction Attorney,23.29
-2119,23,1000,"Lawyers, Judges, and Related Workers",30,Litigation Support Specialist,23.30
+2119,23,1000,"Lawyers, Judges, and Related Workers",30,Litigation Support Specialist,23.3
 2120,23,1000,"Lawyers, Judges, and Related Workers",31,Foreclosure Paralegal,23.31
 2121,23,2000,Legal Support Workers,32,Title Assistant,23.32
 2122,23,2000,Legal Support Workers,33,Patent Agent,23.33
@@ -2127,7 +2127,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2125,23,1000,"Lawyers, Judges, and Related Workers",36,Managing Attorney,23.36
 2126,23,2000,Legal Support Workers,37,Title Specialist,23.37
 2127,23,1000,"Lawyers, Judges, and Related Workers",38,Labor and Employment Attorney,23.38
-2128,23,2000,Legal Support Workers,40,Title Closer,23.40
+2128,23,2000,Legal Support Workers,40,Title Closer,23.4
 2129,23,1000,"Lawyers, Judges, and Related Workers",41,Personal Injury Paralegal,23.41
 2130,23,1000,"Lawyers, Judges, and Related Workers",43,Transactional Paralegal,23.43
 2131,23,1000,"Lawyers, Judges, and Related Workers",44,Compliance Paralegal,23.44
@@ -2135,14 +2135,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2133,23,2000,Legal Support Workers,46,Legal Administrator,23.46
 2134,23,1000,"Lawyers, Judges, and Related Workers",47,Legal Consultant,23.47
 2135,23,1000,"Lawyers, Judges, and Related Workers",49,Litigation Support Analyst,23.49
-2136,23,1000,"Lawyers, Judges, and Related Workers",50,Intellectual Property Attorney,23.50
+2136,23,1000,"Lawyers, Judges, and Related Workers",50,Intellectual Property Attorney,23.5
 2137,23,1000,"Lawyers, Judges, and Related Workers",52,Trusts and Estates Paralegal,23.52
 2138,23,1000,"Lawyers, Judges, and Related Workers",53,Worker's Compensation Paralegal,23.53
 2139,23,1000,"Lawyers, Judges, and Related Workers",55,Mergers and Acquisitions Attorney,23.55
 2140,23,1000,"Lawyers, Judges, and Related Workers",56,Regulator and Compliance Attorney,23.56
 2141,23,1000,"Lawyers, Judges, and Related Workers",58,Bankruptcy Attorney,23.58
 2142,23,1000,"Lawyers, Judges, and Related Workers",59,Intellectual Property Specialist,23.59
-2143,23,1000,"Lawyers, Judges, and Related Workers",60,Insurance Defense Paralegal,23.60
+2143,23,1000,"Lawyers, Judges, and Related Workers",60,Insurance Defense Paralegal,23.6
 2144,23,1000,"Lawyers, Judges, and Related Workers",61,Litigation Counsel,23.61
 2145,23,1000,"Lawyers, Judges, and Related Workers",62,Family Law Paralegal,23.62
 2146,23,1000,"Lawyers, Judges, and Related Workers",63,Patent Legal Assistant,23.63
@@ -2161,7 +2161,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2159,23,1000,"Lawyers, Judges, and Related Workers",77,Foreclosure Attorney,23.77
 2160,23,2000,Legal Support Workers,78,Court Researcher,23.78
 2161,23,1000,"Lawyers, Judges, and Related Workers",79,Finance Paralegal,23.79
-2162,23,1000,"Lawyers, Judges, and Related Workers",80,Compliance Counsel,23.80
+2162,23,1000,"Lawyers, Judges, and Related Workers",80,Compliance Counsel,23.8
 2163,23,1000,"Lawyers, Judges, and Related Workers",81,Director of Patents and Trademarks,23.81
 2164,23,1000,"Lawyers, Judges, and Related Workers",82,Attorney Editor,23.82
 2165,23,1000,"Lawyers, Judges, and Related Workers",83,Project Attorney,23.83
@@ -2171,7 +2171,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2169,23,2000,Legal Support Workers,87,Litigation Manager,23.87
 2170,23,2000,Legal Support Workers,88,Title Clerk (Legal),23.88
 2171,23,1000,"Lawyers, Judges, and Related Workers",89,Insurance Defense Counsel,23.89
-2172,23,1000,"Lawyers, Judges, and Related Workers",90,Employment Law Paralegal,23.90
+2172,23,1000,"Lawyers, Judges, and Related Workers",90,Employment Law Paralegal,23.9
 2173,23,1000,"Lawyers, Judges, and Related Workers",91,Trusts and Estates Attorney,23.91
 2174,23,1000,"Lawyers, Judges, and Related Workers",92,Leasing Paralegal,23.92
 2175,23,1000,"Lawyers, Judges, and Related Workers",93,Assistant Attorney General,23.93
@@ -2180,7 +2180,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2178,23,1000,"Lawyers, Judges, and Related Workers",97,Utilities Paralegal,23.97
 2179,23,2000,Legal Support Workers,98,Paralegal,23.98
 2180,23,1000,"Lawyers, Judges, and Related Workers",99,Mortgage Attorney,23.99
-2181,23,1000,"Lawyers, Judges, and Related Workers",100,Personal Injury Attorney,23.100
+2181,23,1000,"Lawyers, Judges, and Related Workers",100,Personal Injury Attorney,23.1
 2182,23,1000,"Lawyers, Judges, and Related Workers",101,Employment Law Counsel,23.101
 2183,23,2000,Legal Support Workers,102,Title Abstractor,23.102
 2184,23,2000,Legal Support Workers,103,Probate Paralegal,23.103
@@ -2188,7 +2188,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2186,23,1000,"Lawyers, Judges, and Related Workers",106,Contracts Counsel,23.106
 2187,23,2000,Legal Support Workers,107,Patent Clerk,23.107
 2188,23,1000,"Lawyers, Judges, and Related Workers",108,E-Discovery Paralegal,23.108
-2189,23,1000,"Lawyers, Judges, and Related Workers",110,Family Law Attorney,23.110
+2189,23,1000,"Lawyers, Judges, and Related Workers",110,Family Law Attorney,23.11
 2190,23,1000,"Lawyers, Judges, and Related Workers",111,Technology Counsel,23.111
 2191,23,1000,"Lawyers, Judges, and Related Workers",112,Construction Attorney,23.112
 2192,23,1000,"Lawyers, Judges, and Related Workers",113,Paralegal/Administrator,23.113
@@ -2197,7 +2197,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2195,23,1000,"Lawyers, Judges, and Related Workers",116,Nurse Paralegal,23.116
 2196,23,2000,Legal Support Workers,117,Medical Malpractice Paralegal,23.117
 2197,23,2000,Legal Support Workers,119,Title Agent,23.119
-2198,23,1000,"Lawyers, Judges, and Related Workers",120,Financial Services Attorney,23.120
+2198,23,1000,"Lawyers, Judges, and Related Workers",120,Financial Services Attorney,23.12
 2199,23,1000,"Lawyers, Judges, and Related Workers",122,Entertainment Attorney,23.122
 2200,23,2000,Legal Support Workers,124,Bankruptcy Supervisor,23.124
 2201,23,1000,"Lawyers, Judges, and Related Workers",125,Assistant Division Counsel,23.125
@@ -2205,14 +2205,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2203,23,1000,"Lawyers, Judges, and Related Workers",127,In-House Paralegal,23.127
 2204,23,1000,"Lawyers, Judges, and Related Workers",128,Hedge Fund Paralegal,23.128
 2205,23,1000,"Lawyers, Judges, and Related Workers",129,Chief Counsel,23.129
-2206,23,1000,"Lawyers, Judges, and Related Workers",130,Marketing Paralegal,23.130
+2206,23,1000,"Lawyers, Judges, and Related Workers",130,Marketing Paralegal,23.13
 2207,23,1000,"Lawyers, Judges, and Related Workers",131,Litigation Support Assistant,23.131
 2208,23,1000,"Lawyers, Judges, and Related Workers",132,Trademark Counsel,23.132
 2209,23,2000,Legal Support Workers,134,Litigation Clerk,23.134
 2210,23,1000,"Lawyers, Judges, and Related Workers",137,Healthcare Paralegal,23.137
 2211,23,1000,"Lawyers, Judges, and Related Workers",138,Patent Counsel,23.138
 2212,23,1000,"Lawyers, Judges, and Related Workers",139,Technology Attorney,23.139
-2213,23,2000,Legal Support Workers,140,Labor and Employment Paralegal,23.140
+2213,23,2000,Legal Support Workers,140,Labor and Employment Paralegal,23.14
 2214,23,2000,Legal Support Workers,141,Research Attorney,23.141
 2215,23,1000,"Lawyers, Judges, and Related Workers",142,Immigration Attorney,23.142
 2216,23,1000,"Lawyers, Judges, and Related Workers",143,Clinical Paralegal,23.143
@@ -2226,25 +2226,25 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2224,23,1000,"Lawyers, Judges, and Related Workers",155,Deputy General Counsel,23.155
 2225,23,2000,Legal Support Workers,157,Patent Administrator,23.157
 2226,23,1000,"Lawyers, Judges, and Related Workers",159,Technology Paralegal,23.159
-2227,23,2000,Legal Support Workers,160,Patent Specialist,23.160
+2227,23,2000,Legal Support Workers,160,Patent Specialist,23.16
 2228,23,2000,Legal Support Workers,164,Litigation Consultant,23.164
 2229,23,2000,Legal Support Workers,166,Risk Management Paralegal,23.166
 2230,23,1000,"Lawyers, Judges, and Related Workers",167,Operations Counsel,23.167
 2231,23,1000,"Lawyers, Judges, and Related Workers",168,Securities Attorney,23.168
 2232,23,1000,"Lawyers, Judges, and Related Workers",169,Judge,23.169
-2233,23,1000,"Lawyers, Judges, and Related Workers",170,Real Estate Counsel,23.170
+2233,23,1000,"Lawyers, Judges, and Related Workers",170,Real Estate Counsel,23.17
 2234,23,2000,Legal Support Workers,173,Paralegal Clerk,23.173
 2235,23,1000,"Lawyers, Judges, and Related Workers",175,Regulatory Counsel,23.175
 2236,23,1000,"Lawyers, Judges, and Related Workers",176,Research Paralegal,23.176
 2237,23,1000,"Lawyers, Judges, and Related Workers",179,Securities Paralegal,23.179
-2238,23,1000,"Lawyers, Judges, and Related Workers",180,State Attorney,23.180
+2238,23,1000,"Lawyers, Judges, and Related Workers",180,State Attorney,23.18
 2239,23,2000,Legal Support Workers,182,Escrow Assistant (Legal),23.182
 2240,23,1000,"Lawyers, Judges, and Related Workers",184,Healthcare Attorney,23.184
 2241,23,1000,"Lawyers, Judges, and Related Workers",186,Other Topics,23.186
 2242,23,1000,"Lawyers, Judges, and Related Workers",31289,Managing Counsel,23.31289
 2243,23,1000,"Lawyers, Judges, and Related Workers",31238,Client Partner,23.31238
 2244,23,1000,"Lawyers, Judges, and Related Workers",10659,Abstractor,23.10659
-2245,23,1000,"Lawyers, Judges, and Related Workers",30410,General Counsel,23.30410
+2245,23,1000,"Lawyers, Judges, and Related Workers",30410,General Counsel,23.3041
 2246,23,1000,"Lawyers, Judges, and Related Workers",1186,Principal Lawyer,23.1186
 2247,23,1000,"Lawyers, Judges, and Related Workers",1128,In-House Lawyer,23.1128
 2248,23,1000,"Lawyers, Judges, and Related Workers",1069,Employment Lawyer,23.1069
@@ -2256,11 +2256,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2254,23,1000,"Lawyers, Judges, and Related Workers",1303,Ombudsman,23.1303
 2255,23,1000,"Lawyers, Judges, and Related Workers",1178,Court of Appeals Judge,23.1178
 2256,23,2000,Legal Support Workers,1171,Legal Expert,23.1171
-2257,23,1000,"Lawyers, Judges, and Related Workers",1090,Legislative Counsel,23.1090
+2257,23,1000,"Lawyers, Judges, and Related Workers",1090,Legislative Counsel,23.109
 2258,23,1000,"Lawyers, Judges, and Related Workers",1235,Intellectual Property (IP) Partner,23.1235
 2259,23,1000,"Lawyers, Judges, and Related Workers",1204,Tax Counsel,23.1204
 2260,23,2000,Legal Support Workers,1047,Court Reporter,23.1047
-2261,23,1000,"Lawyers, Judges, and Related Workers",1080,International Lawyer,23.1080
+2261,23,1000,"Lawyers, Judges, and Related Workers",1080,International Lawyer,23.108
 2262,23,1000,"Lawyers, Judges, and Related Workers",1074,Presiding Judge,23.1074
 2263,23,1000,"Lawyers, Judges, and Related Workers",1163,Defense Attorney,23.1163
 2264,23,1000,"Lawyers, Judges, and Related Workers",1039,Magistrate,23.1039
@@ -2276,7 +2276,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2274,23,1000,"Lawyers, Judges, and Related Workers",1108,Probate Judge,23.1108
 2275,23,1000,"Lawyers, Judges, and Related Workers",1144,Tax Lawyer,23.1144
 2276,23,2000,Legal Support Workers,1215,Litigation Specialist,23.1215
-2277,23,1000,"Lawyers, Judges, and Related Workers",1220,Appeals Attorney,23.1220
+2277,23,1000,"Lawyers, Judges, and Related Workers",1220,Appeals Attorney,23.122
 2278,23,1000,"Lawyers, Judges, and Related Workers",1021,Solicitor,23.1021
 2279,23,1000,"Lawyers, Judges, and Related Workers",1133,Legal Attorney,23.1133
 2280,23,2000,Legal Support Workers,1244,Litigation Officer,23.1244
@@ -2290,17 +2290,17 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2288,23,1000,"Lawyers, Judges, and Related Workers",1119,Municipal Judge,23.1119
 2289,23,1000,"Lawyers, Judges, and Related Workers",1191,Judicial Attorney,23.1191
 2290,23,1000,"Lawyers, Judges, and Related Workers",1046,Commercial Lawyer,23.1046
-2291,23,2000,Legal Support Workers,1120,Court Specialist,23.1120
+2291,23,2000,Legal Support Workers,1120,Court Specialist,23.112
 2292,23,1000,"Lawyers, Judges, and Related Workers",1019,Court Attorney,23.1019
 2293,23,2000,Legal Support Workers,1174,Legislative Assistant,23.1174
 2294,23,1000,"Lawyers, Judges, and Related Workers",1096,Defense Counsel,23.1096
 2295,23,1000,"Lawyers, Judges, and Related Workers",1132,Foreign Lawyer,23.1132
-2296,23,1000,"Lawyers, Judges, and Related Workers",1170,County Judge,23.1170
+2296,23,1000,"Lawyers, Judges, and Related Workers",1170,County Judge,23.117
 2297,23,2000,Legal Support Workers,1185,Law Advisor,23.1185
 2298,23,1000,"Lawyers, Judges, and Related Workers",1058,Counselor at Law,23.1058
 2299,23,2000,Legal Support Workers,1246,Court Monitor,23.1246
 2300,23,1000,"Lawyers, Judges, and Related Workers",1139,City Attorney,23.1139
-2301,23,1000,"Lawyers, Judges, and Related Workers",1040,Head of Litigation,23.1040
+2301,23,1000,"Lawyers, Judges, and Related Workers",1040,Head of Litigation,23.104
 2302,23,1000,"Lawyers, Judges, and Related Workers",1331,Legal Partner,23.1331
 2303,23,1000,"Lawyers, Judges, and Related Workers",1064,Collaborative Lawyer,23.1064
 2304,23,1000,"Lawyers, Judges, and Related Workers",1075,Corporate Partner,23.1075
@@ -2322,18 +2322,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2320,23,1000,"Lawyers, Judges, and Related Workers",1194,City Judge,23.1194
 2321,23,1000,"Lawyers, Judges, and Related Workers",1192,Founding Partner,23.1192
 2322,23,1000,"Lawyers, Judges, and Related Workers",1018,Prosecutor,23.1018
-2323,23,1000,"Lawyers, Judges, and Related Workers",1190,Staff Judge Advocate,23.1190
+2323,23,1000,"Lawyers, Judges, and Related Workers",1190,Staff Judge Advocate,23.119
 2324,23,1000,"Lawyers, Judges, and Related Workers",1189,Family Lawyer,23.1189
 2325,23,1000,"Lawyers, Judges, and Related Workers",1066,Notary Public (Legal),23.1066
 2326,23,1000,"Lawyers, Judges, and Related Workers",1195,Costs Lawyer,23.1195
-2327,23,2000,Legal Support Workers,1000,Judicial Extern,23.1000
+2327,23,2000,Legal Support Workers,1000,Judicial Extern,23.1
 2328,23,1000,"Lawyers, Judges, and Related Workers",1113,Senior Judge,23.1113
-2329,23,1000,"Lawyers, Judges, and Related Workers",1280,Business Attorney,23.1280
+2329,23,1000,"Lawyers, Judges, and Related Workers",1280,Business Attorney,23.128
 2330,23,1000,"Lawyers, Judges, and Related Workers",1221,Tax Partner,23.1221
 2331,23,2000,Legal Support Workers,1056,Legal Investigator,23.1056
 2332,23,1000,"Lawyers, Judges, and Related Workers",1004,Legal Adviser,23.1004
 2333,23,1000,"Lawyers, Judges, and Related Workers",1065,Appeals Officer,23.1065
-2334,23,1000,"Lawyers, Judges, and Related Workers",1070,Deputy Attorney,23.1070
+2334,23,1000,"Lawyers, Judges, and Related Workers",1070,Deputy Attorney,23.107
 2335,23,1000,"Lawyers, Judges, and Related Workers",1012,Attorney,23.1012
 2336,23,1000,"Lawyers, Judges, and Related Workers",1007,Senior Counsel,23.1007
 2337,23,1000,"Lawyers, Judges, and Related Workers",1008,Mediator,23.1008
@@ -2342,12 +2342,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2340,23,1000,"Lawyers, Judges, and Related Workers",1022,Arbitrator,23.1022
 2341,23,1000,"Lawyers, Judges, and Related Workers",1087,Corporate Lawyer,23.1087
 2342,23,1000,"Lawyers, Judges, and Related Workers",1212,Business Lawyer,23.1212
-2343,23,1000,"Lawyers, Judges, and Related Workers",1330,Trial Counsel,23.1330
+2343,23,1000,"Lawyers, Judges, and Related Workers",1330,Trial Counsel,23.133
 2344,23,1000,"Lawyers, Judges, and Related Workers",1188,Senior Attorney,23.1188
-2345,23,1000,"Lawyers, Judges, and Related Workers",1150,Professional Support Lawyer (PSL),23.1150
+2345,23,1000,"Lawyers, Judges, and Related Workers",1150,Professional Support Lawyer (PSL),23.115
 2346,23,1000,"Lawyers, Judges, and Related Workers",1122,Litigation Lawyer,23.1122
 2347,23,1000,"Lawyers, Judges, and Related Workers",1213,Commercial Counsel,23.1213
-2348,25,1000,Postsecondary Teachers,0,Adjunct Instructor,25.0
+2348,25,1000,Postsecondary Teachers,0,Adjunct Instructor,25
 2349,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1,Preschool Teacher,25.1
 2350,25,9000,"Other Education, Training, and Library Occupations",2,Instructional Designer,25.2
 2351,25,1000,Postsecondary Teachers,3,College Faculty,25.3
@@ -2357,7 +2357,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2355,25,1000,Postsecondary Teachers,7,Teacher,25.7
 2356,25,1000,Postsecondary Teachers,8,Nursing Instructor,25.8
 2357,25,1000,Postsecondary Teachers,9,Instructor,25.9
-2358,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",10,Lead Teacher,25.10
+2358,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",10,Lead Teacher,25.1
 2359,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",11,Teacher Assistant,25.11
 2360,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",12,Toddler Teacher,25.12
 2361,25,1000,Postsecondary Teachers,13,Medical Assistant Instructor,25.13
@@ -2365,7 +2365,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2363,25,1000,Postsecondary Teachers,15,Nursing Faculty,25.15
 2364,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",16,Science Teacher,25.16
 2365,25,9000,"Other Education, Training, and Library Occupations",19,Teacher Aide,25.19
-2366,25,1000,Postsecondary Teachers,20,"Heating, Ventilating and Air Conditioning (HVAC) Instructor",25.20
+2366,25,1000,Postsecondary Teachers,20,"Heating, Ventilating and Air Conditioning (HVAC) Instructor",25.2
 2367,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",21,Substitute Teacher,25.21
 2368,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",22,Health Science Instructor,25.22
 2369,25,1000,Postsecondary Teachers,23,Dental Assistant Instructor,25.23
@@ -2380,7 +2380,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2378,25,1000,Postsecondary Teachers,36,Vocational Instructor,25.36
 2379,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",38,Music Teacher,25.38
 2380,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",39,Spanish Teacher,25.39
-2381,25,9000,"Other Education, Training, and Library Occupations",40,Curriculum Developer,25.40
+2381,25,9000,"Other Education, Training, and Library Occupations",40,Curriculum Developer,25.4
 2382,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",42,Secondary Math Teacher,25.42
 2383,25,3000,Other Teachers and Instructors,43,"Flight Instructor (Education, Training, and Library)",25.43
 2384,25,1000,Postsecondary Teachers,45,Medical Billing and Coding Instructor,25.45
@@ -2388,7 +2388,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2386,25,4000,"Librarians, Curators, and Archivists",47,Librarian,25.47
 2387,25,1000,Postsecondary Teachers,48,Education Coordinator,25.48
 2388,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",49,Head Start Teacher,25.49
-2389,25,1000,Postsecondary Teachers,50,Certified Instructor,25.50
+2389,25,1000,Postsecondary Teachers,50,Certified Instructor,25.5
 2390,25,1000,Postsecondary Teachers,51,"Nurse Educator (Education, Training, and Library)",25.51
 2391,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",52,Social Studies Teacher,25.52
 2392,25,9000,"Other Education, Training, and Library Occupations",53,"Program Director (Education, Training, and Library)",25.53
@@ -2397,14 +2397,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2395,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",57,English as a Second Language (ESL) Teacher,25.57
 2396,25,1000,Postsecondary Teachers,58,Criminal Justice Instructor,25.58
 2397,25,1000,Postsecondary Teachers,59,Massage Therapy Instructor,25.59
-2398,25,1000,Postsecondary Teachers,60,Medical Assisting Faculty,25.60
+2398,25,1000,Postsecondary Teachers,60,Medical Assisting Faculty,25.6
 2399,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",61,Virtual Teacher,25.61
 2400,25,1000,Postsecondary Teachers,62,Department Chair,25.62
 2401,25,9000,"Other Education, Training, and Library Occupations",64,"Education Specialist (Education, Training, and Library)",25.64
 2402,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",67,Mathematics Specialist,25.67
 2403,25,1000,Postsecondary Teachers,68,Electrical Instructor,25.68
 2404,25,1000,Postsecondary Teachers,69,Early Assessment Program (EAP) Test Rater,25.69
-2405,25,1000,Postsecondary Teachers,70,Lead Instructor,25.70
+2405,25,1000,Postsecondary Teachers,70,Lead Instructor,25.7
 2406,25,1000,Postsecondary Teachers,72,Trades Faculty,25.72
 2407,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",76,High School Mathematics Teacher,25.76
 2408,25,9000,"Other Education, Training, and Library Occupations",81,Curriculum Specialist,25.81
@@ -2419,7 +2419,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2417,25,1000,Postsecondary Teachers,94,Certified Nursing Assistant (CNA) Instructor,25.94
 2418,25,1000,Postsecondary Teachers,97,Commercial Driver's License (CDL) Instructor,25.97
 2419,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",98,English as a Second Language (ESL) Instructor,25.98
-2420,25,1000,Postsecondary Teachers,100,Law School Admission Test (LSAT) Instructor,25.100
+2420,25,1000,Postsecondary Teachers,100,Law School Admission Test (LSAT) Instructor,25.1
 2421,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",101,Special Education Generalist,25.101
 2422,25,1000,Postsecondary Teachers,102,X-Ray Instructor,25.102
 2423,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",103,Reading Teacher,25.103
@@ -2428,37 +2428,37 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2426,25,4000,"Librarians, Curators, and Archivists",107,Library Director,25.107
 2427,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",108,Physical Education (PE) Teacher,25.108
 2428,25,1000,Postsecondary Teachers,109,Massage Therapy Faculty,25.109
-2429,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",110,Chemistry Teacher,25.110
+2429,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",110,Chemistry Teacher,25.11
 2430,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",113,Paraprofessional,25.113
 2431,25,1000,Postsecondary Teachers,114,Speech Instructor,25.114
 2432,25,1000,Postsecondary Teachers,115,Accounting Instructor,25.115
 2433,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",116,Computer Teacher,25.116
 2434,25,1000,Postsecondary Teachers,117,Dental Assisting Faculty,25.117
-2435,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",120,Classroom Teacher,25.120
+2435,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",120,Classroom Teacher,25.12
 2436,25,1000,Postsecondary Teachers,121,Adjunct Professor,25.121
 2437,25,1000,Postsecondary Teachers,123,Cryptologic Language Instructor,25.123
 2438,25,3000,Other Teachers and Instructors,125,Reading Instructor,25.125
 2439,25,9000,"Other Education, Training, and Library Occupations",126,"Director of Education (Education, Training, and Library)",25.126
 2440,25,9000,"Other Education, Training, and Library Occupations",127,Veterinary Assistant Instructor,25.127
 2441,25,1000,Postsecondary Teachers,128,English Instructor,25.128
-2442,25,1000,Postsecondary Teachers,130,Psychology Instructor,25.130
+2442,25,1000,Postsecondary Teachers,130,Psychology Instructor,25.13
 2443,25,1000,Postsecondary Teachers,132,Office Administration Instructor,25.132
 2444,25,1000,Postsecondary Teachers,134,Biology Faculty,25.134
 2445,25,1000,Postsecondary Teachers,136,"Clinical Educator (Education, Training, and Library)",25.136
 2446,25,1000,Postsecondary Teachers,137,Lamaze Instructor,25.137
 2447,25,1000,Postsecondary Teachers,139,Loadmaster Instructor,25.139
-2448,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",140,High School Teacher,25.140
+2448,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",140,High School Teacher,25.14
 2449,25,9000,"Other Education, Training, and Library Occupations",141,Classroom Aide,25.141
 2450,25,1000,Postsecondary Teachers,142,Phlebotomy Instructor,25.142
 2451,25,1000,Postsecondary Teachers,143,Master Teacher,25.143
 2452,25,3000,Other Teachers and Instructors,149,Driving Instructor,25.149
-2453,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",150,Welding Instructor,25.150
+2453,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",150,Welding Instructor,25.15
 2454,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",152,Foreign Language Teacher,25.152
 2455,25,4000,"Librarians, Curators, and Archivists",153,Library Specialist,25.153
 2456,25,1000,Postsecondary Teachers,155,Mathematics Instructor,25.155
 2457,25,1000,Postsecondary Teachers,157,Marketing Instructor,25.157
 2458,25,1000,Postsecondary Teachers,159,Department Chair of Nursing,25.159
-2459,25,9000,"Other Education, Training, and Library Occupations",160,Instructional Aide,25.160
+2459,25,9000,"Other Education, Training, and Library Occupations",160,Instructional Aide,25.16
 2460,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",161,General Education Development (GED) Faculty,25.161
 2461,25,1000,Postsecondary Teachers,162,"Clinical Coordinator (Education, Training, and Library)",25.162
 2462,25,1000,Postsecondary Teachers,163,Lecturer,25.163
@@ -2474,25 +2474,25 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2472,25,1000,Postsecondary Teachers,185,Business Instructor,25.185
 2473,25,4000,"Librarians, Curators, and Archivists",186,Research Assistant (RA),25.186
 2474,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",188,4th Grade Teacher,25.188
-2475,25,1000,Postsecondary Teachers,190,Pharmacy Faculty,25.190
+2475,25,1000,Postsecondary Teachers,190,Pharmacy Faculty,25.19
 2476,25,1000,Postsecondary Teachers,192,Spanish Instructor,25.192
 2477,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",193,Floating Teacher,25.193
-2478,25,9000,"Other Education, Training, and Library Occupations",200,Special Education Assistant,25.200
+2478,25,9000,"Other Education, Training, and Library Occupations",200,Special Education Assistant,25.2
 2479,25,9000,"Other Education, Training, and Library Occupations",201,Instructional Developer,25.201
 2480,25,1000,Postsecondary Teachers,207,Radiology Instructor,25.207
-2481,25,1000,Postsecondary Teachers,210,Engineering Faculty,25.210
+2481,25,1000,Postsecondary Teachers,210,Engineering Faculty,25.21
 2482,25,1000,Postsecondary Teachers,217,Clinical Instructor,25.217
 2483,25,1000,Postsecondary Teachers,225,Anatomy Physiology Instructor,25.225
 2484,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",226,3rd Grade Teacher,25.226
 2485,25,1000,Postsecondary Teachers,227,Clinical Faculty,25.227
-2486,25,1000,Postsecondary Teachers,230,Accounting Professor,25.230
+2486,25,1000,Postsecondary Teachers,230,Accounting Professor,25.23
 2487,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",231,Biology Teacher,25.231
 2488,25,1000,Postsecondary Teachers,233,Adjunct Teacher,25.233
 2489,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",235,Art Faculty,25.235
 2490,25,1000,Postsecondary Teachers,236,Media Arts Instructor,25.236
 2491,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",237,Bilingual Teacher,25.237
 2492,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",239,High School Physics Teacher,25.239
-2493,25,1000,Postsecondary Teachers,240,Algebra Instructor,25.240
+2493,25,1000,Postsecondary Teachers,240,Algebra Instructor,25.24
 2494,25,9000,"Other Education, Training, and Library Occupations",247,Proctor,25.247
 2495,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",248,Infant Teacher,25.248
 2496,25,9000,"Other Education, Training, and Library Occupations",249,Curriculum Manager,25.249
@@ -2504,7 +2504,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2502,25,1000,Postsecondary Teachers,30811,Technical Instructor,25.30811
 2503,25,9000,"Other Education, Training, and Library Occupations",11106,School Aide,25.11106
 2504,25,1000,Postsecondary Teachers,30137,Professor,25.30137
-2505,25,9000,"Other Education, Training, and Library Occupations",30850,Learning Consultant,25.30850
+2505,25,9000,"Other Education, Training, and Library Occupations",30850,Learning Consultant,25.3085
 2506,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",30607,Language Instructor,25.30607
 2507,25,1000,Postsecondary Teachers,11047,Content Director,25.11047
 2508,25,1000,Postsecondary Teachers,30846,Act Instructor,25.30846
@@ -2512,42 +2512,42 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2510,25,1000,Postsecondary Teachers,10442,Education Assistant,25.10442
 2511,25,1000,Postsecondary Teachers,30899,Education Instructor,25.30899
 2512,25,4000,"Librarians, Curators, and Archivists",10525,Curator,25.10525
-2513,25,9000,"Other Education, Training, and Library Occupations",30460,"Technician Supervisor (Education, Training, and Library)",25.30460
+2513,25,9000,"Other Education, Training, and Library Occupations",30460,"Technician Supervisor (Education, Training, and Library)",25.3046
 2514,25,1000,Postsecondary Teachers,30957,"Research Fellow (Education, Training, and Library)",25.30957
-2515,25,9000,"Other Education, Training, and Library Occupations",30580,"Educational Technician (Education, Training, and Library)",25.30580
+2515,25,9000,"Other Education, Training, and Library Occupations",30580,"Educational Technician (Education, Training, and Library)",25.3058
 2516,25,9000,"Other Education, Training, and Library Occupations",30839,"Education Consultant (Education, Training, and Library)",25.30839
 2517,25,1000,Postsecondary Teachers,30561,"Department Head (Education, Training, and Library)",25.30561
 2518,25,4000,"Librarians, Curators, and Archivists",1031,Archivist,25.1031
 2519,25,4000,"Librarians, Curators, and Archivists",1071,Library Manager,25.1071
 2520,25,4000,"Librarians, Curators, and Archivists",1135,Preparator,25.1135
 2521,25,1000,Postsecondary Teachers,1137,Philosopher,25.1137
-2522,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1090,Music Assistant,25.1090
-2523,25,1000,Postsecondary Teachers,1160,Head of Science,25.1160
+2522,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1090,Music Assistant,25.109
+2523,25,1000,Postsecondary Teachers,1160,Head of Science,25.116
 2524,25,1000,Postsecondary Teachers,1047,"Laboratory Assistant (Education, Training, and Library)",25.1047
 2525,25,9000,"Other Education, Training, and Library Occupations",1118,"Grader (Education, Training, and Library)",25.1118
 2526,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1004,Educator,25.1004
 2527,25,1000,Postsecondary Teachers,1012,Teaching Fellow,25.1012
 2528,25,4000,"Librarians, Curators, and Archivists",1029,Conservator,25.1029
-2529,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1100,Evaluator,25.1100
+2529,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1100,Evaluator,25.11
 2530,25,1000,Postsecondary Teachers,1036,Head of School,25.1036
 2531,25,9000,"Other Education, Training, and Library Occupations",1099,Paraeducator,25.1099
 2532,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1052,Visiting Fellow,25.1052
-2533,25,1000,Postsecondary Teachers,1040,"Chairperson (Education, Training, and Library)",25.1040
-2534,25,1000,Postsecondary Teachers,1140,Scorer,25.1140
+2533,25,1000,Postsecondary Teachers,1040,"Chairperson (Education, Training, and Library)",25.104
+2534,25,1000,Postsecondary Teachers,1140,Scorer,25.114
 2535,25,1000,Postsecondary Teachers,1003,Graduate Assistant,25.1003
 2536,25,4000,"Librarians, Curators, and Archivists",1059,Head of Library,25.1059
 2537,25,1000,Postsecondary Teachers,1011,Faculty,25.1011
 2538,25,1000,Postsecondary Teachers,1067,Undergraduate Assistant,25.1067
-2539,25,4000,"Librarians, Curators, and Archivists",1060,Cataloger,25.1060
-2540,25,1000,Postsecondary Teachers,1070,"Presenter (Education, Training, and Library)",25.1070
+2539,25,4000,"Librarians, Curators, and Archivists",1060,Cataloger,25.106
+2540,25,1000,Postsecondary Teachers,1070,"Presenter (Education, Training, and Library)",25.107
 2541,25,1000,Postsecondary Teachers,1046,"Mentor (Education, Training, and Library)",25.1046
 2542,25,1000,Postsecondary Teachers,1092,Arts Coordinator,25.1092
 2543,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1061,Art Assistant,25.1061
 2544,25,1000,Postsecondary Teachers,1034,Graduate Fellow,25.1034
 2545,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",1065,Head of Art,25.1065
 2546,25,1000,Postsecondary Teachers,2032,Lecturer in Law,25.2032
-2547,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",2120,Language and Culture Assistant,25.2120
-2548,27,1000,Art and Design Workers,0,Merchandising Specialist,27.0
+2547,25,2000,"Preschool, Primary, Secondary, and Special Education School Teachers",2120,Language and Culture Assistant,25.212
+2548,27,1000,Art and Design Workers,0,Merchandising Specialist,27
 2549,27,1000,Art and Design Workers,1,"Graphic Designer (Arts, Design, Entertainment, Sports, and Media)",27.1
 2550,27,1000,Art and Design Workers,2,Merchandiser,27.2
 2551,27,1000,Art and Design Workers,3,Visual Merchandiser,27.3
@@ -2557,7 +2557,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2555,27,3000,Media and Communication Workers,7,Copy Writer,27.7
 2556,27,3000,Media and Communication Workers,8,"Marketing Specialist (Arts, Design, Entertainment, Sports, and Media)",27.8
 2557,27,1000,Art and Design Workers,9,Interior Designer,27.9
-2558,27,4000,Media and Communication Equipment Workers,10,Newborn Photographer,27.10
+2558,27,4000,Media and Communication Equipment Workers,10,Newborn Photographer,27.1
 2559,27,1000,Art and Design Workers,11,Art Director,27.11
 2560,27,1000,Art and Design Workers,12,Production Artist,27.12
 2561,27,1000,Art and Design Workers,13,Visual Designer,27.13
@@ -2566,7 +2566,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2564,27,3000,Media and Communication Workers,16,Proposal Writer,27.16
 2565,27,3000,Media and Communication Workers,17,Senior Technical Writer,27.17
 2566,27,3000,Media and Communication Workers,18,"Documentation Specialist (Arts, Design, Entertainment, Sports, and Media)",27.18
-2567,27,4000,Media and Communication Equipment Workers,20,Audio Visual (AV) Technician,27.20
+2567,27,4000,Media and Communication Equipment Workers,20,Audio Visual (AV) Technician,27.2
 2568,27,3000,Media and Communication Workers,21,Communications Coordinator,27.21
 2569,27,2000,"Entertainers and Performers, Sports and Related Workers",22,"Program Director (Arts, Design, Entertainment, Sports, and Media)",27.22
 2570,27,1000,Art and Design Workers,23,"Computer Aided Design (CAD) Designer (Arts, Design, Entertainment, Sports and Media)",27.23
@@ -2575,7 +2575,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2573,27,1000,Art and Design Workers,26,Production Designer,27.26
 2574,27,4000,Media and Communication Equipment Workers,27,Preschool Photographer,27.27
 2575,27,3000,Media and Communication Workers,29,Content Writer,27.29
-2576,27,3000,Media and Communication Workers,30,Content Specialist,27.30
+2576,27,3000,Media and Communication Workers,30,Content Specialist,27.3
 2577,27,1000,Art and Design Workers,31,Interactive Designer,27.31
 2578,27,3000,Media and Communication Workers,32,Policy and Procedure Writer,27.32
 2579,27,4000,Media and Communication Equipment Workers,33,"Marketing Assistant (Arts, Design, Entertainment, Sports, and Media)",27.33
@@ -2585,7 +2585,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2583,27,3000,Media and Communication Workers,37,Documentation Writer,27.37
 2584,27,2000,"Entertainers and Performers, Sports and Related Workers",38,Fundraising Coordinator,27.38
 2585,27,3000,Media and Communication Workers,39,Proposal Coordinator,27.39
-2586,27,3000,Media and Communication Workers,40,Brand Advocate,27.40
+2586,27,3000,Media and Communication Workers,40,Brand Advocate,27.4
 2587,27,3000,Media and Communication Workers,41,Engineering Technical Writer,27.41
 2588,27,4000,Media and Communication Equipment Workers,42,School Photographer,27.42
 2589,27,3000,Media and Communication Workers,43,Multimedia Journalist,27.43
@@ -2593,7 +2593,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2591,27,3000,Media and Communication Workers,45,Director of Marketing,27.45
 2592,27,1000,Art and Design Workers,46,Flash Designer,27.46
 2593,27,1000,Art and Design Workers,48,Multimedia Designer,27.48
-2594,27,3000,Media and Communication Workers,50,Junior Technical Writer,27.50
+2594,27,3000,Media and Communication Workers,50,Junior Technical Writer,27.5
 2595,27,3000,Media and Communication Workers,51,Communications Writer,27.51
 2596,27,3000,Media and Communication Workers,52,Social Media Coordinator,27.52
 2597,27,3000,Media and Communication Workers,53,"Marketing Representative (Arts, Design, Entertainment, Sports, and Media)",27.53
@@ -2601,7 +2601,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2599,27,1000,Art and Design Workers,55,Digital Designer,27.55
 2600,27,2000,"Entertainers and Performers, Sports and Related Workers",57,Video Producer,27.57
 2601,27,3000,Media and Communication Workers,59,Technical Translator,27.59
-2602,27,3000,Media and Communication Workers,60,News Producer,27.60
+2602,27,3000,Media and Communication Workers,60,News Producer,27.6
 2603,27,1000,Art and Design Workers,61,Colorist,27.61
 2604,27,2000,"Entertainers and Performers, Sports and Related Workers",62,Merchandising Coordinator,27.62
 2605,27,1000,Art and Design Workers,63,Creative Designer,27.63
@@ -2617,7 +2617,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2615,27,3000,Media and Communication Workers,77,Proposal Specialist,27.77
 2616,27,1000,Art and Design Workers,78,Package Designer,27.78
 2617,27,4000,Media and Communication Equipment Workers,79,"Operations Technician (Arts, Design, Entertainment, Sports, and Media)",27.79
-2618,27,2000,"Entertainers and Performers, Sports and Related Workers",80,Content Producer,27.80
+2618,27,2000,"Entertainers and Performers, Sports and Related Workers",80,Content Producer,27.8
 2619,27,4000,Media and Communication Equipment Workers,82,"Technical Director (Arts, Design, Entertainment, Sports, and Media)",27.82
 2620,27,3000,Media and Communication Workers,83,Community Moderator,27.83
 2621,27,1000,Art and Design Workers,84,Presentation Specialist,27.84
@@ -2626,7 +2626,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2624,27,3000,Media and Communication Workers,87,"Interpreter (Arts, Design, Entertainment, Sports, and Media)",27.87
 2625,27,1000,Art and Design Workers,88,"Web Designer (Arts, Design, Entertainment, Sports, and Media)",27.88
 2626,27,3000,Media and Communication Workers,89,Media Planner,27.89
-2627,27,1000,Art and Design Workers,90,Industrial Designer,27.90
+2627,27,1000,Art and Design Workers,90,Industrial Designer,27.9
 2628,27,2000,"Entertainers and Performers, Sports and Related Workers",91,"Assistant Director (Arts, Design, Entertainment, Sports, and Media)",27.91
 2629,27,3000,Media and Communication Workers,92,News Reporter,27.92
 2630,27,4000,Media and Communication Equipment Workers,93,Master Control Operator (MCO),27.93
@@ -2642,7 +2642,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2640,27,4000,Media and Communication Equipment Workers,106,Producer,27.106
 2641,27,3000,Media and Communication Workers,108,Sports Producer,27.108
 2642,27,2000,"Entertainers and Performers, Sports and Related Workers",109,"Production Coordinator (Arts, Design, Entertainment, Sports, and Media)",27.109
-2643,27,4000,Media and Communication Equipment Workers,110,Videographer,27.110
+2643,27,4000,Media and Communication Equipment Workers,110,Videographer,27.11
 2644,27,1000,Art and Design Workers,111,Retail Merchandiser,27.111
 2645,27,1000,Art and Design Workers,112,Field Merchandising Representative,27.112
 2646,27,1000,Art and Design Workers,114,Illustrator,27.114
@@ -2650,7 +2650,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2648,27,3000,Media and Communication Workers,116,"Account Specialist (Arts, Design, Entertainment, Sports, and Media)",27.116
 2649,27,3000,Media and Communication Workers,117,Anchor,27.117
 2650,27,4000,Media and Communication Equipment Workers,119,News Photographer,27.119
-2651,27,2000,"Entertainers and Performers, Sports and Related Workers",120,Content Coordinator,27.120
+2651,27,2000,"Entertainers and Performers, Sports and Related Workers",120,Content Coordinator,27.12
 2652,27,4000,Media and Communication Equipment Workers,121,"Cable Technician (Arts, Design, Entertainment, Sports, and Media)",27.121
 2653,27,1000,Art and Design Workers,123,3D Artist,27.123
 2654,27,3000,Media and Communication Workers,124,Staff Writer,27.124
@@ -2660,13 +2660,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2658,27,1000,Art and Design Workers,132,"Technical Designer (Arts, Design, Entertainment, Sports, and Media)",27.132
 2659,27,3000,Media and Communication Workers,135,General Assignment Reporter,27.135
 2660,27,4000,Media and Communication Equipment Workers,138,Senior Producer,27.138
-2661,27,2000,"Entertainers and Performers, Sports and Related Workers",140,Assistant Coach,27.140
+2661,27,2000,"Entertainers and Performers, Sports and Related Workers",140,Assistant Coach,27.14
 2662,27,3000,Media and Communication Workers,144,Digital Media Specialist,27.144
 2663,27,3000,Media and Communication Workers,146,Marketing Communications Associate,27.146
 2664,27,1000,Art and Design Workers,148,Animator,27.148
 2665,27,3000,Media and Communication Workers,155,Entry Level Technical Writer,27.155
 2666,27,3000,Media and Communication Workers,157,Social Media Marketing Specialist,27.157
-2667,27,3000,Media and Communication Workers,160,Publicist,27.160
+2667,27,3000,Media and Communication Workers,160,Publicist,27.16
 2668,27,4000,Media and Communication Equipment Workers,163,Photojournalist,27.163
 2669,27,3000,Media and Communication Workers,166,Author,27.166
 2670,27,2000,"Entertainers and Performers, Sports and Related Workers",169,Campaign Coordinator,27.169
@@ -2681,18 +2681,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2679,27,3000,Media and Communication Workers,194,Technical Communicator,27.194
 2680,27,3000,Media and Communication Workers,198,Web Writer,27.198
 2681,27,2000,"Entertainers and Performers, Sports and Related Workers",201,Other Topics,27.201
-2682,27,2000,"Entertainers and Performers, Sports and Related Workers",31120,Women's Soccer Coach,27.31120
+2682,27,2000,"Entertainers and Performers, Sports and Related Workers",31120,Women's Soccer Coach,27.3112
 2683,27,3000,Media and Communication Workers,10303,Translator,27.10303
 2684,27,2000,"Entertainers and Performers, Sports and Related Workers",10938,Singer,27.10938
 2685,27,1000,Art and Design Workers,10695,Sales Designer,27.10695
-2686,27,3000,Media and Communication Workers,30770,Reports Writer,27.30770
+2686,27,3000,Media and Communication Workers,30770,Reports Writer,27.3077
 2687,27,4000,Media and Communication Equipment Workers,10839,Radio Electronics Officer,27.10839
-2688,27,3000,Media and Communication Workers,11390,Publications Coordinator,27.11390
+2688,27,3000,Media and Communication Workers,11390,Publications Coordinator,27.1139
 2689,27,4000,Media and Communication Equipment Workers,30325,Photographer,27.30325
 2690,27,1000,Art and Design Workers,31222,Multimedia Developer,27.31222
 2691,27,3000,Media and Communication Workers,30871,Media Consultant,27.30871
 2692,27,3000,Media and Communication Workers,10423,Journalist,27.10423
-2693,27,3000,Media and Communication Workers,10990,Information Coordinator,27.10990
+2693,27,3000,Media and Communication Workers,10990,Information Coordinator,27.1099
 2694,27,1000,Art and Design Workers,11186,Fashion Designer,27.11186
 2695,27,2000,"Entertainers and Performers, Sports and Related Workers",31161,"Director of Talent Management (Arts, Design, Entertainment, Sports, and Media)",27.31161
 2696,27,2000,"Entertainers and Performers, Sports and Related Workers",10112,Coach,27.10112
@@ -2705,10 +2705,10 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2703,27,1000,Art and Design Workers,31469,"Visual Manager (Arts, Design, Entertainment, Sports, and Media)",27.31469
 2704,27,3000,Media and Communication Workers,31061,"Relations Consultant (Arts, Design, Entertainment, Sports, and Media)",27.31061
 2705,27,2000,"Entertainers and Performers, Sports and Related Workers",30613,"Program Supervisor (Arts, Design, Entertainment, Sports, and Media)",27.30613
-2706,27,1000,Art and Design Workers,30990,"Layout Designer (Arts, Design, Entertainment, Sports, and Media)",27.30990
-2707,27,4000,Media and Communication Equipment Workers,30580,"Educational Technician (Arts, Design, Entertainment, Sports, and Media)",27.30580
+2706,27,1000,Art and Design Workers,30990,"Layout Designer (Arts, Design, Entertainment, Sports, and Media)",27.3099
+2707,27,4000,Media and Communication Equipment Workers,30580,"Educational Technician (Arts, Design, Entertainment, Sports, and Media)",27.3058
 2708,27,1000,Art and Design Workers,30511,"Design Consultant (Arts, Design, Entertainment, Sports, and Media)",27.30511
-2709,27,2000,"Entertainers and Performers, Sports and Related Workers",10380,"Conductor (Arts, Design, Entertainment, Sports, and Media)",27.10380
+2709,27,2000,"Entertainers and Performers, Sports and Related Workers",10380,"Conductor (Arts, Design, Entertainment, Sports, and Media)",27.1038
 2710,27,1000,Art and Design Workers,10824,"Communications Representative (Arts, Design, Entertainment, Sports, and Media)",27.10824
 2711,27,4000,Media and Communication Equipment Workers,30822,"Communications Operator (Arts, Design, Entertainment, Sports, and Media)",27.30822
 2712,27,1000,Art and Design Workers,31583,"Store Merchandiser (Arts, Design, Entertainment, Sports, and Media)",27.31583
@@ -2726,9 +2726,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2724,27,2000,"Entertainers and Performers, Sports and Related Workers",1142,Redactor,27.1142
 2725,27,3000,Media and Communication Workers,1166,Lyricist,27.1166
 2726,27,2000,"Entertainers and Performers, Sports and Related Workers",1086,Production Director,27.1086
-2727,27,3000,Media and Communication Workers,1120,Marketing Officer,27.1120
+2727,27,3000,Media and Communication Workers,1120,Marketing Officer,27.112
 2728,27,3000,Media and Communication Workers,1109,Script Writer,27.1109
-2729,27,1000,Art and Design Workers,1180,Cartoonist,27.1180
+2729,27,1000,Art and Design Workers,1180,Cartoonist,27.118
 2730,27,4000,Media and Communication Equipment Workers,1052,Sound Mixer,27.1052
 2731,27,3000,Media and Communication Workers,1146,Publication Specialist,27.1146
 2732,27,2000,"Entertainers and Performers, Sports and Related Workers",1103,Bassist,27.1103
@@ -2764,10 +2764,10 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2762,27,3000,Media and Communication Workers,1128,Reader,27.1128
 2763,27,2000,"Entertainers and Performers, Sports and Related Workers",1071,Story Teller,27.1071
 2764,27,3000,Media and Communication Workers,1099,"Media Director (Arts, Design, Entertainment, Sports, and Media)",27.1099
-2765,27,2000,"Entertainers and Performers, Sports and Related Workers",1150,Apprentice,27.1150
+2765,27,2000,"Entertainers and Performers, Sports and Related Workers",1150,Apprentice,27.115
 2766,27,2000,"Entertainers and Performers, Sports and Related Workers",1175,Co-Director,27.1175
 2767,27,2000,"Entertainers and Performers, Sports and Related Workers",1054,Band Director,27.1054
-2768,27,3000,Media and Communication Workers,1060,"Social Media Manager (Arts, Design, Entertainment, Sports, and Media)",27.1060
+2768,27,3000,Media and Communication Workers,1060,"Social Media Manager (Arts, Design, Entertainment, Sports, and Media)",27.106
 2769,27,2000,"Entertainers and Performers, Sports and Related Workers",1061,Scout,27.1061
 2770,27,2000,"Entertainers and Performers, Sports and Related Workers",1159,Soloist,27.1159
 2771,27,2000,"Entertainers and Performers, Sports and Related Workers",1158,Clown,27.1158
@@ -2777,7 +2777,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2775,27,3000,Media and Communication Workers,1106,Director of Sports,27.1106
 2776,27,3000,Media and Communication Workers,1026,Entertainer,27.1026
 2777,27,3000,Media and Communication Workers,1062,"Marketing Manager (Arts, Design, Entertainment, Sports, and Media)",27.1062
-2778,27,3000,Media and Communication Workers,1140,"Director of Communications (Arts, Design, Entertainment, Sports, and Media)",27.1140
+2778,27,3000,Media and Communication Workers,1140,"Director of Communications (Arts, Design, Entertainment, Sports, and Media)",27.114
 2779,27,2000,"Entertainers and Performers, Sports and Related Workers",1029,Dancer,27.1029
 2780,27,2000,"Entertainers and Performers, Sports and Related Workers",1088,Guitarist,27.1088
 2781,27,4000,Media and Communication Equipment Workers,1208,Media Assistant,27.1208
@@ -2786,7 +2786,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2784,27,3000,Media and Communication Workers,1211,Novelist,27.1211
 2785,27,2000,"Entertainers and Performers, Sports and Related Workers",1069,"Board Member (Arts, Design, Entertainment, Sports, and Media)",27.1069
 2786,27,3000,Media and Communication Workers,1157,"Director of Public Relations (Arts, Design, Entertainment, Sports and Media)",27.1157
-2787,27,2000,"Entertainers and Performers, Sports and Related Workers",1010,Musician,27.1010
+2787,27,2000,"Entertainers and Performers, Sports and Related Workers",1010,Musician,27.101
 2788,27,3000,Media and Communication Workers,1076,Television Host,27.1076
 2789,27,2000,"Entertainers and Performers, Sports and Related Workers",1055,Film Director,27.1055
 2790,27,3000,Media and Communication Workers,1093,"Marketing Director (Arts, Design, Entertainment, Sports, and Media)",27.1093
@@ -2797,17 +2797,17 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2795,27,2000,"Entertainers and Performers, Sports and Related Workers",1102,Trainer,27.1102
 2796,27,4000,Media and Communication Equipment Workers,1073,Communications Assistant,27.1073
 2797,27,3000,Media and Communication Workers,1051,Publisher,27.1051
-2798,27,2000,"Entertainers and Performers, Sports and Related Workers",1020,Musical Director,27.1020
+2798,27,2000,"Entertainers and Performers, Sports and Related Workers",1020,Musical Director,27.102
 2799,27,1000,Art and Design Workers,1002,Designer,27.1002
 2800,27,3000,Media and Communication Workers,1189,Playwright,27.1189
 2801,27,2000,"Entertainers and Performers, Sports and Related Workers",1034,Vocalist,27.1034
 2802,27,1000,Art and Design Workers,1111,"Craftsman (Arts, Design, Entertainment, Sports, and Media)",27.1111
 2803,27,2000,"Entertainers and Performers, Sports and Related Workers",1144,"Director of Operations (Arts, Design, Entertainment, Sports and Media)",27.1144
-2804,27,3000,Media and Communication Workers,1080,Consultant Writer,27.1080
+2804,27,3000,Media and Communication Workers,1080,Consultant Writer,27.108
 2805,27,3000,Media and Communication Workers,1017,Reporter,27.1017
 2806,27,2000,"Entertainers and Performers, Sports and Related Workers",1047,Drummer,27.1047
-2807,27,4000,Media and Communication Equipment Workers,1000,Disk Jockey (DJ),27.1000
-2808,27,1000,Art and Design Workers,1160,"Painter (Arts, Design, Entertainment, Sports and Media)",27.1160
+2807,27,4000,Media and Communication Equipment Workers,1000,Disk Jockey (DJ),27.1
+2808,27,1000,Art and Design Workers,1160,"Painter (Arts, Design, Entertainment, Sports and Media)",27.116
 2809,27,3000,Media and Communication Workers,1192,Co-Editor,27.1192
 2810,27,3000,Media and Communication Workers,1037,Features Writer,27.1037
 2811,27,2000,"Entertainers and Performers, Sports and Related Workers",1057,Pianist,27.1057
@@ -2820,7 +2820,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2818,27,4000,Media and Communication Equipment Workers,1098,Sound Engineer,27.1098
 2819,27,4000,Media and Communication Equipment Workers,1053,"Production Manager (Arts, Design, Entertainment, Sports, and Media)",27.1053
 2820,27,3000,Media and Communication Workers,1089,Reviewer,27.1089
-2821,27,3000,Media and Communication Workers,1190,Critic,27.1190
+2821,27,3000,Media and Communication Workers,1190,Critic,27.119
 2822,27,3000,Media and Communication Workers,1204,Poet,27.1204
 2823,27,4000,Media and Communication Equipment Workers,1072,"Production Assistant (Arts, Design, Entertainment, Sports, and Media)",27.1072
 2824,27,3000,Media and Communication Workers,1038,Correspondent,27.1038
@@ -2828,9 +2828,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2826,27,1000,Art and Design Workers,1001,Artist,27.1001
 2827,27,2000,"Entertainers and Performers, Sports and Related Workers",1056,"Promoter (Arts, Design, Entertainment, Sports, and Media)",27.1056
 2828,27,2000,"Entertainers and Performers, Sports and Related Workers",1043,Music Composer,27.1043
-2829,27,3000,Media and Communication Workers,1210,Percussionist,27.1210
+2829,27,3000,Media and Communication Workers,1210,Percussionist,27.121
 2830,27,3000,Media and Communication Workers,1044,Blogger,27.1044
-2831,29,1000,Health Diagnosing and Treating Practitioners,0,Registered Nurse,29.0
+2831,29,1000,Health Diagnosing and Treating Practitioners,0,Registered Nurse,29
 2832,29,1000,Health Diagnosing and Treating Practitioners,1,Physical Therapist,29.1
 2833,29,1000,Health Diagnosing and Treating Practitioners,2,Nurse Practitioner,29.2
 2834,29,1000,Health Diagnosing and Treating Practitioners,3,Licensed Practical Nurse (LPN),29.3
@@ -2840,7 +2840,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2838,29,1000,Health Diagnosing and Treating Practitioners,7,Nurse Supervisor,29.7
 2839,29,1000,Health Diagnosing and Treating Practitioners,8,Speech Therapist,29.8
 2840,29,1000,Health Diagnosing and Treating Practitioners,9,Nurse Manager (Healthcare Practitioners and Technical),29.9
-2841,29,1000,Health Diagnosing and Treating Practitioners,10,Clinical Nurse,29.10
+2841,29,1000,Health Diagnosing and Treating Practitioners,10,Clinical Nurse,29.1
 2842,29,1000,Health Diagnosing and Treating Practitioners,11,Case Manager (Healthcare Practitioners and Technical),29.11
 2843,29,1000,Health Diagnosing and Treating Practitioners,12,Staff Nurse,29.12
 2844,29,1000,Health Diagnosing and Treating Practitioners,13,Emergency Room (ER) Nurse,29.13
@@ -2850,7 +2850,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2848,29,1000,Health Diagnosing and Treating Practitioners,17,Labor and Delivery Nurse,29.17
 2849,29,1000,Health Diagnosing and Treating Practitioners,18,Surgical Unit Nurse,29.18
 2850,29,1000,Health Diagnosing and Treating Practitioners,19,Medical Coder,29.19
-2851,29,2000,Health Technologists and Technicians,20,Respiratory Therapist,29.20
+2851,29,2000,Health Technologists and Technicians,20,Respiratory Therapist,29.2
 2852,29,2000,Health Technologists and Technicians,21,Laboratory Technician (Healthcare Practitioners and Technical),29.21
 2853,29,2000,Health Technologists and Technicians,22,Emergency Medical Technician (EMT),29.22
 2854,29,2000,Health Technologists and Technicians,23,Patient Care Technician (Healthcare Practitioners and Technical),29.23
@@ -2860,7 +2860,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2858,29,1000,Health Diagnosing and Treating Practitioners,27,Utilization Review Nurse,29.27
 2859,29,1000,Health Diagnosing and Treating Practitioners,28,Progressive Care Unit (PCU) Nurse,29.28
 2860,29,2000,Health Technologists and Technicians,29,Ultrasound Technician,29.29
-2861,29,1000,Health Diagnosing and Treating Practitioners,30,Neonatal Intensive Care Unit (NICU) Nurse,29.30
+2861,29,1000,Health Diagnosing and Treating Practitioners,30,Neonatal Intensive Care Unit (NICU) Nurse,29.3
 2862,29,1000,Health Diagnosing and Treating Practitioners,31,Pharmacy Manager (Healthcare Practitioners and Technical),29.31
 2863,29,1000,Health Diagnosing and Treating Practitioners,32,Clinical Coordinator (Healthcare Practitioners and Technical),29.32
 2864,29,1000,Health Diagnosing and Treating Practitioners,33,Rehabilitation Coordinator,29.33
@@ -2870,7 +2870,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2868,29,1000,Health Diagnosing and Treating Practitioners,37,Nurse Educator (Healthcare Practitioners and Technical),29.37
 2869,29,1000,Health Diagnosing and Treating Practitioners,38,Minimum Data Set (MDS) Coordinator,29.38
 2870,29,2000,Health Technologists and Technicians,39,Medical Records Clerk,29.39
-2871,29,1000,Health Diagnosing and Treating Practitioners,40,Charge Nurse,29.40
+2871,29,1000,Health Diagnosing and Treating Practitioners,40,Charge Nurse,29.4
 2872,29,1000,Health Diagnosing and Treating Practitioners,41,Triage Nurse,29.41
 2873,29,9000,Other Healthcare Practitioners and Technical Occupations,42,Safety Specialist,29.42
 2874,29,2000,Health Technologists and Technicians,43,Clinical Documentation Specialist,29.43
@@ -2880,7 +2880,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2878,29,2000,Health Technologists and Technicians,47,Monitor Technician,29.47
 2879,29,2000,Health Technologists and Technicians,48,Medical Technician,29.48
 2880,29,2000,Health Technologists and Technicians,49,Radiology Technician,29.49
-2881,29,1000,Health Diagnosing and Treating Practitioners,50,Occupational Health Nurse,29.50
+2881,29,1000,Health Diagnosing and Treating Practitioners,50,Occupational Health Nurse,29.5
 2882,29,2000,Health Technologists and Technicians,51,Release of Information Specialist,29.51
 2883,29,1000,Health Diagnosing and Treating Practitioners,52,Pediatric Intensive Care Unit (PICU) Nurse,29.52
 2884,29,2000,Health Technologists and Technicians,53,MRI Technologist,29.53
@@ -2890,7 +2890,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2888,29,1000,Health Diagnosing and Treating Practitioners,57,Wound Care Nurse,29.57
 2889,29,1000,Health Diagnosing and Treating Practitioners,58,Infusion Nurse,29.58
 2890,29,1000,Health Diagnosing and Treating Practitioners,59,HEDIS Review Nurse,29.59
-2891,29,1000,Health Diagnosing and Treating Practitioners,60,Inpatient Services Nurse,29.60
+2891,29,1000,Health Diagnosing and Treating Practitioners,60,Inpatient Services Nurse,29.6
 2892,29,1000,Health Diagnosing and Treating Practitioners,61,Travel Nurse - Cardiac Catheterization Laboratory,29.61
 2893,29,2000,Health Technologists and Technicians,62,Dental Hygienist,29.62
 2894,29,1000,Health Diagnosing and Treating Practitioners,63,Dialysis Nurse,29.63
@@ -2900,7 +2900,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2898,29,1000,Health Diagnosing and Treating Practitioners,67,Research Nurse,29.67
 2899,29,1000,Health Diagnosing and Treating Practitioners,68,Travel Nurse - Medical/Surgical,29.68
 2900,29,1000,Health Diagnosing and Treating Practitioners,69,School Nurse,29.69
-2901,29,1000,Health Diagnosing and Treating Practitioners,70,Patient Care Coordinator,29.70
+2901,29,1000,Health Diagnosing and Treating Practitioners,70,Patient Care Coordinator,29.7
 2902,29,1000,Health Diagnosing and Treating Practitioners,71,Registered Dietician,29.71
 2903,29,1000,Health Diagnosing and Treating Practitioners,72,Dentist,29.72
 2904,29,1000,Health Diagnosing and Treating Practitioners,73,Cardiovascular Operating Room (CVOR) Nurse,29.73
@@ -2909,7 +2909,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2907,29,1000,Health Diagnosing and Treating Practitioners,77,Clinical Nurse Consultant,29.77
 2908,29,1000,Health Diagnosing and Treating Practitioners,78,Quality Improvement Nurse,29.78
 2909,29,1000,Health Diagnosing and Treating Practitioners,79,Recreational Therapist,29.79
-2910,29,1000,Health Diagnosing and Treating Practitioners,80,Activity Director,29.80
+2910,29,1000,Health Diagnosing and Treating Practitioners,80,Activity Director,29.8
 2911,29,1000,Health Diagnosing and Treating Practitioners,81,Medical Review Nurse,29.81
 2912,29,2000,Health Technologists and Technicians,82,Medical Records Specialist,29.82
 2913,29,2000,Health Technologists and Technicians,83,Laboratory Technologist,29.83
@@ -2919,7 +2919,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2917,29,1000,Health Diagnosing and Treating Practitioners,87,Patient Care Manager,29.87
 2918,29,9000,Other Healthcare Practitioners and Technical Occupations,88,Health and Safety Officer,29.88
 2919,29,1000,Health Diagnosing and Treating Practitioners,89,Medical Program Coordinator,29.89
-2920,29,1000,Health Diagnosing and Treating Practitioners,90,Director of Pharmacy (Healthcare Practitioners and Technical),29.90
+2920,29,1000,Health Diagnosing and Treating Practitioners,90,Director of Pharmacy (Healthcare Practitioners and Technical),29.9
 2921,29,2000,Health Technologists and Technicians,91,Clinical Technician,29.91
 2922,29,1000,Health Diagnosing and Treating Practitioners,92,Resident Care Manager,29.92
 2923,29,1000,Health Diagnosing and Treating Practitioners,93,Rehabilitation Liaison,29.93
@@ -2928,7 +2928,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2926,29,1000,Health Diagnosing and Treating Practitioners,96,Cardiac Catheterization Laboratory Nurse,29.96
 2927,29,1000,Health Diagnosing and Treating Practitioners,97,Case Manager Supervisor,29.97
 2928,29,2000,Health Technologists and Technicians,99,Ophthalmic Technician,29.99
-2929,29,2000,Health Technologists and Technicians,100,Therapy Technician,29.100
+2929,29,2000,Health Technologists and Technicians,100,Therapy Technician,29.1
 2930,29,2000,Health Technologists and Technicians,102,Histology Technician,29.102
 2931,29,2000,Health Technologists and Technicians,103,Medical Reimbursement Specialist,29.103
 2932,29,1000,Health Diagnosing and Treating Practitioners,105,Home Health Nurse,29.105
@@ -2936,7 +2936,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2934,29,2000,Health Technologists and Technicians,107,Medical Records Technician,29.107
 2935,29,2000,Health Technologists and Technicians,108,Electroencephalography (EEG) Technician,29.108
 2936,29,2000,Health Technologists and Technicians,109,Remote Medical Coder,29.109
-2937,29,1000,Health Diagnosing and Treating Practitioners,110,Health Coach (Healthcare Practitioners and Technical),29.110
+2937,29,1000,Health Diagnosing and Treating Practitioners,110,Health Coach (Healthcare Practitioners and Technical),29.11
 2938,29,2000,Health Technologists and Technicians,111,Health Information Specialist,29.111
 2939,29,2000,Health Technologists and Technicians,112,Laboratory Supervisor (Healthcare Practitioners and Technical),29.112
 2940,29,2000,Health Technologists and Technicians,113,Sonographer,29.113
@@ -2946,7 +2946,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2944,29,2000,Health Technologists and Technicians,117,Health Information Management (HIM) Manager,29.117
 2945,29,1000,Health Diagnosing and Treating Practitioners,118,Nurse Coordinator,29.118
 2946,29,1000,Health Diagnosing and Treating Practitioners,119,Employee Health Nurse,29.119
-2947,29,1000,Health Diagnosing and Treating Practitioners,120,Therapy Supervisor,29.120
+2947,29,1000,Health Diagnosing and Treating Practitioners,120,Therapy Supervisor,29.12
 2948,29,1000,Health Diagnosing and Treating Practitioners,121,Advance Practice Registered Nurse (APRN),29.121
 2949,29,1000,Health Diagnosing and Treating Practitioners,122,Nurse Auditor,29.122
 2950,29,1000,Health Diagnosing and Treating Practitioners,123,Veterinarian,29.123
@@ -2956,7 +2956,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2954,29,2000,Health Technologists and Technicians,127,Technician Assistant,29.127
 2955,29,2000,Health Technologists and Technicians,128,Clinical Analyst (Healthcare Practitioners and Technical),29.128
 2956,29,1000,Health Diagnosing and Treating Practitioners,129,Oncology Nurse,29.129
-2957,29,1000,Health Diagnosing and Treating Practitioners,130,Community Health Nurse,29.130
+2957,29,1000,Health Diagnosing and Treating Practitioners,130,Community Health Nurse,29.13
 2958,29,1000,Health Diagnosing and Treating Practitioners,131,Director of Nursing (Healthcare Practitioners and Technical),29.131
 2959,29,2000,Health Technologists and Technicians,132,Optician,29.132
 2960,29,1000,Health Diagnosing and Treating Practitioners,133,Pediatrics Nurse,29.133
@@ -2965,7 +2965,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2963,29,1000,Health Diagnosing and Treating Practitioners,137,Health and Wellness Director,29.137
 2964,29,1000,Health Diagnosing and Treating Practitioners,138,Advanced Registered Nurse Practitioner (ARNP),29.138
 2965,29,1000,Health Diagnosing and Treating Practitioners,139,Endoscopy Nurse,29.139
-2966,29,1000,Health Diagnosing and Treating Practitioners,140,Clinical Director (Healthcare Practitioners and Technical),29.140
+2966,29,1000,Health Diagnosing and Treating Practitioners,140,Clinical Director (Healthcare Practitioners and Technical),29.14
 2967,29,1000,Health Diagnosing and Treating Practitioners,141,Audiologist,29.141
 2968,29,1000,Health Diagnosing and Treating Practitioners,142,Dietitian,29.142
 2969,29,1000,Health Diagnosing and Treating Practitioners,143,Ambulatory Care Nurse,29.143
@@ -2974,14 +2974,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2972,29,1000,Health Diagnosing and Treating Practitioners,146,Hospitalist,29.146
 2973,29,1000,Health Diagnosing and Treating Practitioners,148,Healthcare Coordinator,29.148
 2974,29,1000,Health Diagnosing and Treating Practitioners,149,Hospice Nurse,29.149
-2975,29,1000,Health Diagnosing and Treating Practitioners,150,Recovery Room Nurse,29.150
+2975,29,1000,Health Diagnosing and Treating Practitioners,150,Recovery Room Nurse,29.15
 2976,29,1000,Health Diagnosing and Treating Practitioners,152,Telemetry Nurse,29.152
 2977,29,1000,Health Diagnosing and Treating Practitioners,153,Special Procedures Nurse,29.153
 2978,29,2000,Health Technologists and Technicians,155,Dialysis Technician,29.155
 2979,29,1000,Health Diagnosing and Treating Practitioners,156,Rehabilitation Nurse,29.156
 2980,29,2000,Health Technologists and Technicians,158,Office Nurse,29.158
 2981,29,1000,Health Diagnosing and Treating Practitioners,159,Obstetrics Nurse,29.159
-2982,29,1000,Health Diagnosing and Treating Practitioners,160,Clinical Nurse Leader,29.160
+2982,29,1000,Health Diagnosing and Treating Practitioners,160,Clinical Nurse Leader,29.16
 2983,29,1000,Health Diagnosing and Treating Practitioners,161,Nursing Staff Development Coordinator,29.161
 2984,29,1000,Health Diagnosing and Treating Practitioners,162,Medical-Surgical Nurse,29.162
 2985,29,1000,Health Diagnosing and Treating Practitioners,164,On-site Nurse,29.164
@@ -2989,9 +2989,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 2987,29,1000,Health Diagnosing and Treating Practitioners,166,Cardiac Care Nurse,29.166
 2988,29,1000,Health Diagnosing and Treating Practitioners,167,Stepdown Nurse,29.167
 2989,29,2000,Health Technologists and Technicians,168,Cardiovascular Technologist,29.168
-2990,29,1000,Health Diagnosing and Treating Practitioners,170,Other Topics,29.170
+2990,29,1000,Health Diagnosing and Treating Practitioners,170,Other Topics,29.17
 2991,29,1000,Health Diagnosing and Treating Practitioners,30037,Physician Assistant (PA),29.30037
-2992,29,2000,Health Technologists and Technicians,30660,Obstetrics (OB) Technician,29.30660
+2992,29,2000,Health Technologists and Technicians,30660,Obstetrics (OB) Technician,29.3066
 2993,29,1000,Health Diagnosing and Treating Practitioners,30826,Nursing Supervisor,29.30826
 2994,29,1000,Health Diagnosing and Treating Practitioners,31152,Medical-Surgical Nurse Manager,29.31152
 2995,29,2000,Health Technologists and Technicians,30606,Magnetic Resonance Imaging (MRI) Technician,29.30606
@@ -3009,9 +3009,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3007,29,1000,Health Diagnosing and Treating Practitioners,30288,Speech Language Pathologist,29.30288
 3008,29,2000,Health Technologists and Technicians,31174,Sleep Technologist,29.31174
 3009,29,2000,Health Technologists and Technicians,30483,Respiratory Care Practitioner,29.30483
-3010,29,1000,Health Diagnosing and Treating Practitioners,11050,Resource Nurse,29.11050
+3010,29,1000,Health Diagnosing and Treating Practitioners,11050,Resource Nurse,29.1105
 3011,29,2000,Health Technologists and Technicians,10427,Registered Respiratory Therapist,29.10427
-3012,29,2000,Health Technologists and Technicians,11370,Records Technician,29.11370
+3012,29,2000,Health Technologists and Technicians,11370,Records Technician,29.1137
 3013,29,1000,Health Diagnosing and Treating Practitioners,10101,Radiologist,29.10101
 3014,29,1000,Health Diagnosing and Treating Practitioners,30656,Radiation Therapist,29.30656
 3015,29,2000,Health Technologists and Technicians,10537,Psychiatric Technician,29.10537
@@ -3041,7 +3041,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3039,29,2000,Health Technologists and Technicians,11421,Cytotechnologist,29.11421
 3040,29,2000,Health Technologists and Technicians,30976,Collection Technician,29.30976
 3041,29,1000,Health Diagnosing and Treating Practitioners,10577,Clinical Reviewer,29.10577
-3042,29,1000,Health Diagnosing and Treating Practitioners,11230,Clinical Partner,29.11230
+3042,29,1000,Health Diagnosing and Treating Practitioners,11230,Clinical Partner,29.1123
 3043,29,1000,Health Diagnosing and Treating Practitioners,30351,Clinical Dietitian,29.30351
 3044,29,1000,Health Diagnosing and Treating Practitioners,31101,Clinical Consultant,29.31101
 3045,29,1000,Health Diagnosing and Treating Practitioners,31275,Charge Dialysis Nurse,29.31275
@@ -3050,12 +3050,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3048,29,9000,Other Healthcare Practitioners and Technical Occupations,30469,Athletic Trainer,29.30469
 3049,29,2000,Health Technologists and Technicians,10563,Animal Technician,29.10563
 3050,29,1000,Health Diagnosing and Treating Practitioners,30106,Licensed Vocational Nurse (LVN),29.30106
-3051,29,1000,Health Diagnosing and Treating Practitioners,30600,Unit Supervisor,29.30600
+3051,29,1000,Health Diagnosing and Treating Practitioners,30600,Unit Supervisor,29.306
 3052,29,2000,Health Technologists and Technicians,30344,Ultrasound Technologist,29.30344
 3053,29,2000,Health Technologists and Technicians,11183,Surgery Coordinator,29.11183
 3054,29,1000,Health Diagnosing and Treating Practitioners,31221,Surgeon,29.31221
 3055,29,9000,Other Healthcare Practitioners and Technical Occupations,30944,Safety Technician,29.30944
-3056,29,2000,Health Technologists and Technicians,10560,Radiographer,29.10560
+3056,29,2000,Health Technologists and Technicians,10560,Radiographer,29.1056
 3057,29,1000,Health Diagnosing and Treating Practitioners,11443,Practice Assistant,29.11443
 3058,29,1000,Health Diagnosing and Treating Practitioners,11769,Pediatric Assistant,29.11769
 3059,29,1000,Health Diagnosing and Treating Practitioners,31506,Nurse Care Coordinator,29.31506
@@ -3063,15 +3063,15 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3061,29,1000,Health Diagnosing and Treating Practitioners,11681,Night Nurse,29.11681
 3062,29,1000,Health Diagnosing and Treating Practitioners,10535,Immunologist,29.10535
 3063,29,2000,Health Technologists and Technicians,30411,Imaging Technician,29.30411
-3064,29,2000,Health Technologists and Technicians,11280,Imaging Assistant,29.11280
+3064,29,2000,Health Technologists and Technicians,11280,Imaging Assistant,29.1128
 3065,29,2000,Health Technologists and Technicians,31311,Health Information Coder,29.31311
 3066,29,1000,Health Diagnosing and Treating Practitioners,10344,Clinical Liaison,29.10344
-3067,29,2000,Health Technologists and Technicians,30920,Cardiology Technician,29.30920
+3067,29,2000,Health Technologists and Technicians,30920,Cardiology Technician,29.3092
 3068,29,1000,Health Diagnosing and Treating Practitioners,10292,Cardiologist,29.10292
 3069,29,2000,Health Technologists and Technicians,11664,Cardiac Technician,29.11664
 3070,29,1000,Health Diagnosing and Treating Practitioners,30954,Wellness Nurse,29.30954
 3071,29,2000,Health Technologists and Technicians,30094,Surgical Technician,29.30094
-3072,29,1000,Health Diagnosing and Treating Practitioners,30800,Staff Physician,29.30800
+3072,29,1000,Health Diagnosing and Treating Practitioners,30800,Staff Physician,29.308
 3073,29,9000,Other Healthcare Practitioners and Technical Occupations,31429,Safety Assistant,29.31429
 3074,29,1000,Health Diagnosing and Treating Practitioners,30419,Review Nurse,29.30419
 3075,29,2000,Health Technologists and Technicians,30333,Paramedic,29.30333
@@ -3081,19 +3081,19 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3079,29,1000,Health Diagnosing and Treating Practitioners,30487,Certified Professional Coder,29.30487
 3080,29,2000,Health Technologists and Technicians,30924,Behavioral Health Technician,29.30924
 3081,29,2000,Health Technologists and Technicians,30576,Scrub Technician,29.30576
-3082,29,1000,Health Diagnosing and Treating Practitioners,30200,Nurse Technician,29.30200
+3082,29,1000,Health Diagnosing and Treating Practitioners,30200,Nurse Technician,29.302
 3083,29,1000,Health Diagnosing and Treating Practitioners,30782,Family Practice Physician,29.30782
 3084,29,2000,Health Technologists and Technicians,30788,Cardiovascular Technician,29.30788
-3085,29,1000,Health Diagnosing and Treating Practitioners,30760,Graduate Nurse,29.30760
+3085,29,1000,Health Diagnosing and Treating Practitioners,30760,Graduate Nurse,29.3076
 3086,29,2000,Health Technologists and Technicians,30662,Emergency Department Technician,29.30662
 3087,29,1000,Health Diagnosing and Treating Practitioners,30654,Anesthesia Technician,29.30654
-3088,29,1000,Health Diagnosing and Treating Practitioners,31240,Nurse Manager Intensive Care Unit (ICU) (Healthcare Practitioners and Technical),29.31240
-3089,29,9000,Other Healthcare Practitioners and Technical Occupations,30880,"Environmental, Health, and Safety (EHS) Manager (Healthcare Practitioners and Technical)",29.30880
-3090,29,2000,Health Technologists and Technicians,30460,Technician Supervisor (Healthcare Practitioners and Technical),29.30460
+3088,29,1000,Health Diagnosing and Treating Practitioners,31240,Nurse Manager Intensive Care Unit (ICU) (Healthcare Practitioners and Technical),29.3124
+3089,29,9000,Other Healthcare Practitioners and Technical Occupations,30880,"Environmental, Health, and Safety (EHS) Manager (Healthcare Practitioners and Technical)",29.3088
+3090,29,2000,Health Technologists and Technicians,30460,Technician Supervisor (Healthcare Practitioners and Technical),29.3046
 3091,29,1000,Health Diagnosing and Treating Practitioners,30735,Technical Supervisor (Healthcare Practitioners and Technical),29.30735
 3092,29,9000,Other Healthcare Practitioners and Technical Occupations,30601,Team Member Trainer (Healthcare Practitioners and Technical),29.30601
-3093,29,1000,Health Diagnosing and Treating Practitioners,10720,Student Nurse (Healthcare Practitioners and Technical),29.10720
-3094,29,2000,Health Technologists and Technicians,10790,Specimen Technician (Healthcare Practitioners and Technical),29.10790
+3093,29,1000,Health Diagnosing and Treating Practitioners,10720,Student Nurse (Healthcare Practitioners and Technical),29.1072
+3094,29,2000,Health Technologists and Technicians,10790,Specimen Technician (Healthcare Practitioners and Technical),29.1079
 3095,29,9000,Other Healthcare Practitioners and Technical Occupations,30985,Safety Inspector (Healthcare Practitioners and Technical),29.30985
 3096,29,1000,Health Diagnosing and Treating Practitioners,30852,Records Analyst (Healthcare Practitioners and Technical),29.30852
 3097,29,1000,Health Diagnosing and Treating Practitioners,11124,Medical Clerk (Healthcare Practitioners and Technical),29.11124
@@ -3116,17 +3116,17 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3114,29,1000,Health Diagnosing and Treating Practitioners,1278,Periodontist,29.1278
 3115,29,1000,Health Diagnosing and Treating Practitioners,1139,Pediatric Resident,29.1139
 3116,29,1000,Health Diagnosing and Treating Practitioners,1223,OB/GYN (Obstetrician / Gynecologist),29.1223
-3117,29,2000,Health Technologists and Technicians,1250,Perfusionist,29.1250
+3117,29,2000,Health Technologists and Technicians,1250,Perfusionist,29.125
 3118,29,1000,Health Diagnosing and Treating Practitioners,1027,Care Coordinator,29.1027
 3119,29,1000,Health Diagnosing and Treating Practitioners,1166,Internist,29.1166
-3120,29,1000,Health Diagnosing and Treating Practitioners,1110,Anesthesiologist,29.1110
+3120,29,1000,Health Diagnosing and Treating Practitioners,1110,Anesthesiologist,29.111
 3121,29,1000,Health Diagnosing and Treating Practitioners,1133,Head of Department,29.1133
 3122,29,1000,Health Diagnosing and Treating Practitioners,1088,Specialist Registrar,29.1088
 3123,29,2000,Health Technologists and Technicians,1215,Prosthetist,29.1215
 3124,29,1000,Health Diagnosing and Treating Practitioners,1202,Health Supervisor (Healthcare Practitioners and Technical),29.1202
 3125,29,1000,Health Diagnosing and Treating Practitioners,1238,Podiatrist,29.1238
 3126,29,9000,Other Healthcare Practitioners and Technical Occupations,1021,Safety Advisor,29.1021
-3127,29,1000,Health Diagnosing and Treating Practitioners,1090,Health Practitioner,29.1090
+3127,29,1000,Health Diagnosing and Treating Practitioners,1090,Health Practitioner,29.109
 3128,29,1000,Health Diagnosing and Treating Practitioners,1045,Physiotherapist,29.1045
 3129,29,1000,Health Diagnosing and Treating Practitioners,1201,Doula (Healthcare Practitioners and Technical),29.1201
 3130,29,9000,Other Healthcare Practitioners and Technical Occupations,1107,Medical Consultant,29.1107
@@ -3138,7 +3138,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3136,29,2000,Health Technologists and Technicians,1135,Health Technician,29.1135
 3137,29,1000,Health Diagnosing and Treating Practitioners,1212,Gastroenterologist,29.1212
 3138,29,2000,Health Technologists and Technicians,1205,Orthotist,29.1205
-3139,29,1000,Health Diagnosing and Treating Practitioners,1020,Nurse Specialist,29.1020
+3139,29,1000,Health Diagnosing and Treating Practitioners,1020,Nurse Specialist,29.102
 3140,29,1000,Health Diagnosing and Treating Practitioners,1062,Chiropractor,29.1062
 3141,29,1000,Health Diagnosing and Treating Practitioners,1049,Surgical Resident,29.1049
 3142,29,9000,Other Healthcare Practitioners and Technical Occupations,1148,Safety Trainer,29.1148
@@ -3148,7 +3148,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3146,29,1000,Health Diagnosing and Treating Practitioners,1096,Medical Specialist,29.1096
 3147,29,1000,Health Diagnosing and Treating Practitioners,1039,Clinical Specialist,29.1039
 3148,29,1000,Health Diagnosing and Treating Practitioners,1114,Senior Nurse,29.1114
-3149,29,1000,Health Diagnosing and Treating Practitioners,1190,Home Care Nurse,29.1190
+3149,29,1000,Health Diagnosing and Treating Practitioners,1190,Home Care Nurse,29.119
 3150,29,9000,Other Healthcare Practitioners and Technical Occupations,1047,Safety Consultant (Healthcare Practitioners and Technical),29.1047
 3151,29,1000,Health Diagnosing and Treating Practitioners,1181,Reiki Master,29.1181
 3152,29,1000,Health Diagnosing and Treating Practitioners,1005,Doctor,29.1005
@@ -3159,7 +3159,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3157,29,1000,Health Diagnosing and Treating Practitioners,2048,Craniosacral Therapist,29.2048
 3158,29,1000,Health Diagnosing and Treating Practitioners,2065,Reflexologist,29.2065
 3159,29,2000,Health Technologists and Technicians,2088,Certified Pedorthist,29.2088
-3160,31,1000,"Nursing, Psychiatric, and Home Health Aides",0,Certified Nursing Assistant (CNA),31.0
+3160,31,1000,"Nursing, Psychiatric, and Home Health Aides",0,Certified Nursing Assistant (CNA),31
 3161,31,9000,Other Healthcare Support Occupations,1,Medical Assistant,31.1
 3162,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,2,Physical Therapist Assistant (PTA),31.2
 3163,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,3,Certified Occupational Therapy Assistant (COTA),31.3
@@ -3169,7 +3169,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3167,31,1000,"Nursing, Psychiatric, and Home Health Aides",7,Patient Care Assistant,31.7
 3168,31,1000,"Nursing, Psychiatric, and Home Health Aides",8,Nurse Aide,31.8
 3169,31,9000,Other Healthcare Support Occupations,9,Dental Assistant,31.9
-3170,31,9000,Other Healthcare Support Occupations,10,Phlebotomist,31.10
+3170,31,9000,Other Healthcare Support Occupations,10,Phlebotomist,31.1
 3171,31,1000,"Nursing, Psychiatric, and Home Health Aides",11,Patient Transporter,31.11
 3172,31,9000,Other Healthcare Support Occupations,12,Sterile Processing Technician,31.12
 3173,31,9000,Other Healthcare Support Occupations,13,Laboratory Assistant (Healthcare Support),31.13
@@ -3187,14 +3187,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3185,31,9000,Other Healthcare Support Occupations,27,Medical Equipment Technician,31.27
 3186,31,1000,"Nursing, Psychiatric, and Home Health Aides",28,Geriatric Nursing Assistant (GNA),31.28
 3187,31,9000,Other Healthcare Support Occupations,29,Rehabilitation Technician (Healthcare Support),31.29
-3188,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,30,Rehabilitation Aide,31.30
+3188,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,30,Rehabilitation Aide,31.3
 3189,31,9000,Other Healthcare Support Occupations,32,Pharmacy Clerk,31.32
 3190,31,1000,"Nursing, Psychiatric, and Home Health Aides",33,Certified Medication Aide (CMA),31.33
 3191,31,9000,Other Healthcare Support Occupations,34,Massage Therapist,31.34
 3192,31,9000,Other Healthcare Support Occupations,36,Orthodontic Assistant,31.36
 3193,31,9000,Other Healthcare Support Occupations,37,Radiology Assistant,31.37
 3194,31,9000,Other Healthcare Support Occupations,38,Instrument Technician,31.38
-3195,31,1000,"Nursing, Psychiatric, and Home Health Aides",40,Patient Sitter,31.40
+3195,31,1000,"Nursing, Psychiatric, and Home Health Aides",40,Patient Sitter,31.4
 3196,31,9000,Other Healthcare Support Occupations,42,Healthcare Assistant,31.42
 3197,31,1000,"Nursing, Psychiatric, and Home Health Aides",43,Resident Care Assistant,31.43
 3198,31,9000,Other Healthcare Support Occupations,44,Endoscopy Technician,31.44
@@ -3215,11 +3215,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3213,31,9000,Other Healthcare Support Occupations,76,Unit Assistant,31.76
 3214,31,9000,Other Healthcare Support Occupations,77,Gastrointestinal Technician,31.77
 3215,31,9000,Other Healthcare Support Occupations,79,Sterile Supply Technician,31.79
-3216,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,80,Rehabilitation Assistant,31.80
+3216,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,80,Rehabilitation Assistant,31.8
 3217,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,81,Restorative Aide,31.81
 3218,31,2000,Occupational Therapy and Physical Therapist Assistants and Aides,82,Licensed Physical Therapist Assistant (LPTA),31.82
 3219,31,1000,"Nursing, Psychiatric, and Home Health Aides",84,Certified Home Health Aide,31.84
-3220,31,1000,"Nursing, Psychiatric, and Home Health Aides",90,Emergency Department Nursing Assistant,31.90
+3220,31,1000,"Nursing, Psychiatric, and Home Health Aides",90,Emergency Department Nursing Assistant,31.9
 3221,31,1000,"Nursing, Psychiatric, and Home Health Aides",91,Surgical Aide,31.91
 3222,31,9000,Other Healthcare Support Occupations,692,Other Topics,31.692
 3223,31,1000,"Nursing, Psychiatric, and Home Health Aides",11532,Licensed Nursing Assistant (LNA),31.11532
@@ -3233,11 +3233,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3231,31,9000,Other Healthcare Support Occupations,10342,Nutrition Assistant,31.10342
 3232,31,1000,"Nursing, Psychiatric, and Home Health Aides",11111,Nurse Attendant,31.11111
 3233,31,1000,"Nursing, Psychiatric, and Home Health Aides",10748,Clinical Informaticist,31.10748
-3234,31,1000,"Nursing, Psychiatric, and Home Health Aides",10010,Nurse Assistant,31.10010
+3234,31,1000,"Nursing, Psychiatric, and Home Health Aides",10010,Nurse Assistant,31.1001
 3235,31,9000,Other Healthcare Support Occupations,10078,Clinical Assistant,31.10078
 3236,31,1000,"Nursing, Psychiatric, and Home Health Aides",10984,Patient Scheduler (Healthcare Support),31.10984
 3237,31,9000,Other Healthcare Support Occupations,30382,Unit Clerk (Healthcare Support),31.30382
-3238,31,1000,"Nursing, Psychiatric, and Home Health Aides",10720,Student Nurse (Healthcare Support),31.10720
+3238,31,1000,"Nursing, Psychiatric, and Home Health Aides",10720,Student Nurse (Healthcare Support),31.1072
 3239,31,1000,"Nursing, Psychiatric, and Home Health Aides",31234,Hospital Service Technician (Healthcare Support),31.31234
 3240,31,9000,Other Healthcare Support Occupations,10187,Unit Coordinator (Healthcare Support),31.10187
 3241,31,1000,"Nursing, Psychiatric, and Home Health Aides",10587,Transportation Aide (Healthcare Support),31.10587
@@ -3261,7 +3261,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3259,31,1000,"Nursing, Psychiatric, and Home Health Aides",1049,Home Care Worker,31.1049
 3260,31,1000,"Nursing, Psychiatric, and Home Health Aides",1002,Nursing Assistant,31.1002
 3261,31,1000,"Nursing, Psychiatric, and Home Health Aides",1036,Healthcare Worker,31.1036
-3262,33,3000,Law Enforcement Workers,0,Security Officer (Protective Service),33.0
+3262,33,3000,Law Enforcement Workers,0,Security Officer (Protective Service),33
 3263,33,9000,Other Protective Service Workers,1,Loss Prevention Manager (Protective Service),33.1
 3264,33,9000,Other Protective Service Workers,2,Upscale Security Officer,33.2
 3265,33,9000,Other Protective Service Workers,4,Custom Protection Officer,33.4
@@ -3270,7 +3270,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3268,33,9000,Other Protective Service Workers,7,Loss Prevention Detective,33.7
 3269,33,9000,Other Protective Service Workers,8,Retail Door Guard,33.8
 3270,33,9000,Other Protective Service Workers,9,Loss Prevention Lead,33.9
-3271,33,3000,Law Enforcement Workers,10,Armed Security Officer,33.10
+3271,33,3000,Law Enforcement Workers,10,Armed Security Officer,33.1
 3272,33,3000,Law Enforcement Workers,11,Office of Personnel Management (OPM) Credentialed Investigator,33.11
 3273,33,3000,Law Enforcement Workers,12,Police Officer,33.12
 3274,33,3000,Law Enforcement Workers,13,Correctional Officer,33.13
@@ -3279,7 +3279,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3277,33,9000,Other Protective Service Workers,17,Loss Prevention Agent,33.17
 3278,33,9000,Other Protective Service Workers,18,Bank Protection Officer,33.18
 3279,33,9000,Other Protective Service Workers,19,Loss Prevention Associate,33.19
-3280,33,1000,Supervisors of Protective Service Workers,20,Security Manager (Protective Service),33.20
+3280,33,1000,Supervisors of Protective Service Workers,20,Security Manager (Protective Service),33.2
 3281,33,3000,Law Enforcement Workers,21,Police Records Manager,33.21
 3282,33,3000,Law Enforcement Workers,24,Improvised Explosive Device (IED) Insurgent Analyst,33.24
 3283,33,3000,Law Enforcement Workers,25,All-Source Intelligence Analyst,33.25
@@ -3287,7 +3287,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3285,33,3000,Law Enforcement Workers,27,Counterterrorism Analyst,33.27
 3286,33,9000,Other Protective Service Workers,28,Fraud Prevention Representative,33.28
 3287,33,9000,Other Protective Service Workers,29,Loss Prevention Specialist,33.29
-3288,33,3000,Law Enforcement Workers,30,Patrol Officer,33.30
+3288,33,3000,Law Enforcement Workers,30,Patrol Officer,33.3
 3289,33,3000,Law Enforcement Workers,31,Property Resource Officer,33.31
 3290,33,3000,Law Enforcement Workers,32,Counterintelligence Analyst,33.32
 3291,33,3000,Law Enforcement Workers,33,Signals Intelligence (SIGINT) Analyst,33.33
@@ -3296,12 +3296,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3294,33,3000,Law Enforcement Workers,37,Law Enforcement Officer,33.37
 3295,33,9000,Other Protective Service Workers,38,Loss Prevention Investigator,33.38
 3296,33,9000,Other Protective Service Workers,39,Lifeguard,33.39
-3297,33,2000,Fire Fighting and Prevention Workers,40,Fire Fighter,33.40
+3297,33,2000,Fire Fighting and Prevention Workers,40,Fire Fighter,33.4
 3298,33,9000,Other Protective Service Workers,41,Loss Prevention Supervisor,33.41
 3299,33,3000,Law Enforcement Workers,43,Public Safety Officer,33.43
 3300,33,9000,Other Protective Service Workers,46,Safety and Security Officer,33.46
 3301,33,1000,Supervisors of Protective Service Workers,49,Security Director,33.49
-3302,33,9000,Other Protective Service Workers,50,Security Specialist,33.50
+3302,33,9000,Other Protective Service Workers,50,Security Specialist,33.5
 3303,33,3000,Law Enforcement Workers,52,Facility Security Officer,33.52
 3304,33,9000,Other Protective Service Workers,53,Security Guard,33.53
 3305,33,9000,Other Protective Service Workers,54,Event Security Officer,33.54
@@ -3310,14 +3310,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3308,33,3000,Law Enforcement Workers,57,Weapons Technical Intelligence (WTI) Analyst,33.57
 3309,33,9000,Other Protective Service Workers,58,Security Coordinator,33.58
 3310,33,9000,Other Protective Service Workers,59,Asset Protection Manager,33.59
-3311,33,3000,Law Enforcement Workers,60,Critical Facility Officer,33.60
+3311,33,3000,Law Enforcement Workers,60,Critical Facility Officer,33.6
 3312,33,9000,Other Protective Service Workers,61,Security Dispatcher,33.61
 3313,33,1000,Supervisors of Protective Service Workers,62,Assistant Shift Supervisor,33.62
 3314,33,9000,Other Protective Service Workers,63,Security Assistant,33.63
 3315,33,9000,Other Protective Service Workers,65,Background Investigator,33.65
 3316,33,3000,Law Enforcement Workers,66,Latent Print Examiner,33.66
 3317,33,2000,Fire Fighting and Prevention Workers,69,Fire Inspector,33.69
-3318,33,3000,Law Enforcement Workers,70,Security Investigator,33.70
+3318,33,3000,Law Enforcement Workers,70,Security Investigator,33.7
 3319,33,3000,Law Enforcement Workers,72,Reserve Guard,33.72
 3320,33,9000,Other Protective Service Workers,73,Nuclear Security Officer,33.73
 3321,33,3000,Law Enforcement Workers,74,Healthcare Security Officer,33.74
@@ -3333,7 +3333,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3331,33,2000,Fire Fighting and Prevention Workers,86,Fire Chief,33.86
 3332,33,9000,Other Protective Service Workers,87,Campus Security Officer,33.87
 3333,33,9000,Other Protective Service Workers,88,Driver/Guard,33.88
-3334,33,9000,Other Protective Service Workers,90,Warehouse Security Officer,33.90
+3334,33,9000,Other Protective Service Workers,90,Warehouse Security Officer,33.9
 3335,33,1000,Supervisors of Protective Service Workers,92,Lieutenant (Protective Service),33.92
 3336,33,1000,Supervisors of Protective Service Workers,94,Sergeant (Protective Service),33.94
 3337,33,9000,Other Protective Service Workers,95,Security Analyst,33.95
@@ -3353,7 +3353,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3351,33,3000,Law Enforcement Workers,30754,Field Investigator (Protective Service),33.30754
 3352,33,3000,Law Enforcement Workers,30595,Counterintelligence Officer (Protective Service),33.30595
 3353,33,2000,Fire Fighting and Prevention Workers,30679,Control Officer (Protective Service),33.30679
-3354,33,3000,Law Enforcement Workers,10630,Armed Officer (Protective Service),33.10630
+3354,33,3000,Law Enforcement Workers,10630,Armed Officer (Protective Service),33.1063
 3355,33,1000,Supervisors of Protective Service Workers,1162,Communications Sergeant,33.1162
 3356,33,1000,Supervisors of Protective Service Workers,1108,Team Sergeant,33.1108
 3357,33,3000,Law Enforcement Workers,1163,Corrections Deputy,33.1163
@@ -3363,17 +3363,17 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3361,33,1000,Supervisors of Protective Service Workers,1212,Police Lieutenant,33.1212
 3362,33,3000,Law Enforcement Workers,1188,County Deputy,33.1188
 3363,33,1000,Supervisors of Protective Service Workers,1118,Senior Sergeant,33.1118
-3364,33,1000,Supervisors of Protective Service Workers,1160,Crew Commander,33.1160
+3364,33,1000,Supervisors of Protective Service Workers,1160,Crew Commander,33.116
 3365,33,1000,Supervisors of Protective Service Workers,1175,Corrections Lieutenant,33.1175
 3366,33,3000,Law Enforcement Workers,1107,Court Officer,33.1107
 3367,33,3000,Law Enforcement Workers,1156,Deputy Supervisor,33.1156
 3368,33,3000,Law Enforcement Workers,1084,Police Commander,33.1084
 3369,33,1000,Supervisors of Protective Service Workers,1145,Corrections Supervisor,33.1145
 3370,33,2000,Fire Fighting and Prevention Workers,1157,Fire Instructor,33.1157
-3371,33,9000,Other Protective Service Workers,1140,Security Advisor (Protective Service),33.1140
+3371,33,9000,Other Protective Service Workers,1140,Security Advisor (Protective Service),33.114
 3372,33,3000,Law Enforcement Workers,1085,Senior Investigator,33.1085
 3373,33,2000,Fire Fighting and Prevention Workers,1248,Fire Engineer (Protective Service),33.1248
-3374,33,2000,Fire Fighting and Prevention Workers,1100,Operations Manager (Protective Service),33.1100
+3374,33,2000,Fire Fighting and Prevention Workers,1100,Operations Manager (Protective Service),33.11
 3375,33,1000,Supervisors of Protective Service Workers,1246,Training Chief,33.1246
 3376,33,3000,Law Enforcement Workers,1135,Sergeant at Arms,33.1135
 3377,33,2000,Fire Fighting and Prevention Workers,1067,Fire Captain,33.1067
@@ -3394,14 +3394,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3392,33,3000,Law Enforcement Workers,1159,Jail Administrator,33.1159
 3393,33,1000,Supervisors of Protective Service Workers,1062,Corrections Sergeant,33.1062
 3394,33,1000,Supervisors of Protective Service Workers,1044,Police Sergeant,33.1044
-3395,33,3000,Law Enforcement Workers,1040,Liaison Officer (Protective Service),33.1040
+3395,33,3000,Law Enforcement Workers,1040,Liaison Officer (Protective Service),33.104
 3396,33,9000,Other Protective Service Workers,1168,Corporate Investigator,33.1168
 3397,33,1000,Supervisors of Protective Service Workers,1128,Patrol Lieutenant,33.1128
 3398,33,2000,Fire Fighting and Prevention Workers,1081,Enforcement Manager,33.1081
 3399,33,3000,Law Enforcement Workers,1165,Screening Officer,33.1165
 3400,33,2000,Fire Fighting and Prevention Workers,1032,Inspector,33.1032
 3401,33,1000,Supervisors of Protective Service Workers,1203,Battalion Sergeant,33.1203
-3402,33,2000,Fire Fighting and Prevention Workers,1130,Fire Specialist,33.1130
+3402,33,2000,Fire Fighting and Prevention Workers,1130,Fire Specialist,33.113
 3403,33,2000,Fire Fighting and Prevention Workers,1059,Rescue Swimmer,33.1059
 3404,33,9000,Other Protective Service Workers,1048,Head of Security,33.1048
 3405,33,3000,Law Enforcement Workers,1114,Traffic Officer,33.1114
@@ -3423,7 +3423,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3421,33,3000,Law Enforcement Workers,1088,Division Deputy,33.1088
 3422,33,3000,Law Enforcement Workers,1042,Peace Officer,33.1042
 3423,33,1000,Supervisors of Protective Service Workers,1018,Staff Sergeant (Protective Service),33.1018
-3424,33,2000,Fire Fighting and Prevention Workers,1000,Firefighter,33.1000
+3424,33,2000,Fire Fighting and Prevention Workers,1000,Firefighter,33.1
 3425,33,3000,Law Enforcement Workers,1092,Patrolman,33.1092
 3426,33,3000,Law Enforcement Workers,1229,Jailer,33.1229
 3427,33,3000,Law Enforcement Workers,1166,Federal Officer,33.1166
@@ -3436,18 +3436,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3434,33,1000,Supervisors of Protective Service Workers,1087,Superintendent (Protective Service),33.1087
 3435,33,1000,Supervisors of Protective Service Workers,1133,Section Sergeant,33.1133
 3436,33,1000,Supervisors of Protective Service Workers,1052,Patrol Sergeant,33.1052
-3437,33,1000,Supervisors of Protective Service Workers,1180,Captain of Operations,33.1180
+3437,33,1000,Supervisors of Protective Service Workers,1180,Captain of Operations,33.118
 3438,33,3000,Law Enforcement Workers,1007,Officer in Charge (OIC) (Protective Service),33.1007
 3439,33,3000,Law Enforcement Workers,1193,Deputy Investigator,33.1193
 3440,33,3000,Law Enforcement Workers,1066,Constable,33.1066
 3441,33,3000,Law Enforcement Workers,1125,Chief Investigator,33.1125
 3442,33,3000,Law Enforcement Workers,1161,Investigative Agent,33.1161
 3443,33,1000,Supervisors of Protective Service Workers,1082,Division Chief,33.1082
-3444,33,3000,Law Enforcement Workers,1090,Investigator Officer,33.1090
+3444,33,3000,Law Enforcement Workers,1090,Investigator Officer,33.109
 3445,33,1000,Supervisors of Protective Service Workers,1104,Chief of Police,33.1104
 3446,33,2000,Fire Fighting and Prevention Workers,1101,Fire Marshal,33.1101
 3447,33,3000,Law Enforcement Workers,1167,Police Investigator,33.1167
-3448,35,1000,Supervisors of Food Preparation and Serving Workers,0,Restaurant Manager (Food Preparation and Serving Related),35.0
+3448,35,1000,Supervisors of Food Preparation and Serving Workers,0,Restaurant Manager (Food Preparation and Serving Related),35
 3449,35,1000,Supervisors of Food Preparation and Serving Workers,1,Restaurant Crew Team Member,35.1
 3450,35,3000,Food and Beverage Serving Workers,2,Food Service Worker,35.2
 3451,35,9000,Other Food Preparation and Serving Related Workers,3,Dishwasher,35.3
@@ -3457,7 +3457,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3455,35,1000,Supervisors of Food Preparation and Serving Workers,7,Restaurant Shift Supervisor,35.7
 3456,35,1000,Supervisors of Food Preparation and Serving Workers,8,Sous Chef,35.8
 3457,35,1000,Supervisors of Food Preparation and Serving Workers,9,Executive Chef (Food Preparation and Serving Related),35.9
-3458,35,1000,Supervisors of Food Preparation and Serving Workers,10,Catering Coordinator,35.10
+3458,35,1000,Supervisors of Food Preparation and Serving Workers,10,Catering Coordinator,35.1
 3459,35,9000,Other Food Preparation and Serving Related Workers,11,Host/Hostess (Food Preparation and Serving Related),35.11
 3460,35,3000,Food and Beverage Serving Workers,12,Server,35.12
 3461,35,1000,Supervisors of Food Preparation and Serving Workers,13,Food Service Foreman,35.13
@@ -3465,7 +3465,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3463,35,9000,Other Food Preparation and Serving Related Workers,16,Busser,35.16
 3464,35,1000,Supervisors of Food Preparation and Serving Workers,17,Chef Manager (Food Preparation and Serving Related),35.17
 3465,35,1000,Supervisors of Food Preparation and Serving Workers,19,Assistant General Manager,35.19
-3466,35,1000,Supervisors of Food Preparation and Serving Workers,20,Food Service Supervisor,35.20
+3466,35,1000,Supervisors of Food Preparation and Serving Workers,20,Food Service Supervisor,35.2
 3467,35,3000,Food and Beverage Serving Workers,21,Banquet Server,35.21
 3468,35,9000,Other Food Preparation and Serving Related Workers,22,Bartender,35.22
 3469,35,1000,Supervisors of Food Preparation and Serving Workers,23,Catering Manager (Food Preparation and Serving Related),35.23
@@ -3474,7 +3474,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3472,35,3000,Food and Beverage Serving Workers,27,Food Server,35.27
 3473,35,1000,Supervisors of Food Preparation and Serving Workers,28,Food Operations Manager,35.28
 3474,35,1000,Supervisors of Food Preparation and Serving Workers,29,Food and Beverage Manager,35.29
-3475,35,2000,Cooks and Food Preparation Workers,30,Baker (Food Preparation and Serving Related),35.30
+3475,35,2000,Cooks and Food Preparation Workers,30,Baker (Food Preparation and Serving Related),35.3
 3476,35,1000,Supervisors of Food Preparation and Serving Workers,31,Food Production Manager,35.31
 3477,35,2000,Cooks and Food Preparation Workers,33,Cook,35.33
 3478,35,2000,Cooks and Food Preparation Workers,34,Meat Clerk,35.34
@@ -3482,7 +3482,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3480,35,9000,Other Food Preparation and Serving Related Workers,36,Kitchen Steward,35.36
 3481,35,3000,Food and Beverage Serving Workers,37,Food Service Technician,35.37
 3482,35,1000,Supervisors of Food Preparation and Serving Workers,38,Fresh Foods Cake Decorator,35.38
-3483,35,3000,Food and Beverage Serving Workers,40,Deli-Bakery Clerk,35.40
+3483,35,3000,Food and Beverage Serving Workers,40,Deli-Bakery Clerk,35.4
 3484,35,3000,Food and Beverage Serving Workers,42,Food Runner,35.42
 3485,35,2000,Cooks and Food Preparation Workers,43,Kitchen Worker (Food Preparation and Serving Related),35.43
 3486,35,1000,Supervisors of Food Preparation and Serving Workers,44,Deli Manager,35.44
@@ -3496,7 +3496,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3494,35,2000,Cooks and Food Preparation Workers,55,Kitchen Utitlity Worker,35.55
 3495,35,1000,Supervisors of Food Preparation and Serving Workers,56,Banquet Manager,35.56
 3496,35,3000,Food and Beverage Serving Workers,58,Cocktail Server,35.58
-3497,35,3000,Food and Beverage Serving Workers,60,Food Assembler,35.60
+3497,35,3000,Food and Beverage Serving Workers,60,Food Assembler,35.6
 3498,35,1000,Supervisors of Food Preparation and Serving Workers,64,Speciality Coffee Assistant Manager,35.64
 3499,35,3000,Food and Beverage Serving Workers,65,Food and Beverage Server,35.65
 3500,35,1000,Supervisors of Food Preparation and Serving Workers,67,Deli Chef,35.67
@@ -3516,7 +3516,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3514,35,1000,Supervisors of Food Preparation and Serving Workers,85,Prepared Foods Team Leader,35.85
 3515,35,1000,Supervisors of Food Preparation and Serving Workers,87,Dining Services Manager,35.87
 3516,35,9000,Other Food Preparation and Serving Related Workers,89,Restaurant Hostess,35.89
-3517,35,2000,Cooks and Food Preparation Workers,90,Assistant Chef,35.90
+3517,35,2000,Cooks and Food Preparation Workers,90,Assistant Chef,35.9
 3518,35,1000,Supervisors of Food Preparation and Serving Workers,93,Crew Lead,35.93
 3519,35,1000,Supervisors of Food Preparation and Serving Workers,94,Assistant Shift Manager,35.94
 3520,35,1000,Supervisors of Food Preparation and Serving Workers,95,Multi-Unit Restaurant Manager,35.95
@@ -3524,7 +3524,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3522,35,9000,Other Food Preparation and Serving Related Workers,697,Other Topics,35.697
 3523,35,2000,Cooks and Food Preparation Workers,30794,Lead Cook,35.30794
 3524,35,3000,Food and Beverage Serving Workers,30636,Server Assistant,35.30636
-3525,35,1000,Supervisors of Food Preparation and Serving Workers,30220,Restaurant Supervisor,35.30220
+3525,35,1000,Supervisors of Food Preparation and Serving Workers,30220,Restaurant Supervisor,35.3022
 3526,35,2000,Cooks and Food Preparation Workers,31405,Dietary Cook,35.31405
 3527,35,2000,Cooks and Food Preparation Workers,10088,Chef,35.10088
 3528,35,3000,Food and Beverage Serving Workers,10823,Breakfast Attendant,35.10823
@@ -3532,10 +3532,10 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3530,35,2000,Cooks and Food Preparation Workers,30316,Bakery Clerk,35.30316
 3531,35,9000,Other Food Preparation and Serving Related Workers,10715,Bar Attendant,35.10715
 3532,35,9000,Other Food Preparation and Serving Related Workers,30462,Greeter (Food Preparation and Serving Related),35.30462
-3533,35,1000,Supervisors of Food Preparation and Serving Workers,31270,General Supervisor (Food Preparation and Serving Related),35.31270
+3533,35,1000,Supervisors of Food Preparation and Serving Workers,31270,General Supervisor (Food Preparation and Serving Related),35.3127
 3534,35,3000,Food and Beverage Serving Workers,30214,Food Clerk (Food Preparation and Serving Related),35.30214
 3535,35,3000,Food and Beverage Serving Workers,10795,Counter Person (Food Preparation and Serving Related),35.10795
-3536,35,1000,Supervisors of Food Preparation and Serving Workers,31500,Bakery Manager (Food Preparation and Serving Related),35.31500
+3536,35,1000,Supervisors of Food Preparation and Serving Workers,31500,Bakery Manager (Food Preparation and Serving Related),35.315
 3537,35,2000,Cooks and Food Preparation Workers,30253,Prep Cook,35.30253
 3538,35,3000,Food and Beverage Serving Workers,30921,Bistro Server,35.30921
 3539,35,2000,Cooks and Food Preparation Workers,30249,Deli Clerk (Food Preparation and Serving Related),35.30249
@@ -3547,12 +3547,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3545,35,2000,Cooks and Food Preparation Workers,30975,Banquet Cook,35.30975
 3546,35,3000,Food and Beverage Serving Workers,1047,Food Attendant,35.1047
 3547,35,9000,Other Food Preparation and Serving Related Workers,1011,Busboy,35.1011
-3548,35,3000,Food and Beverage Serving Workers,1080,Reservationist (Food Preparation and Serving Related),35.1080
+3548,35,3000,Food and Beverage Serving Workers,1080,Reservationist (Food Preparation and Serving Related),35.108
 3549,35,3000,Food and Beverage Serving Workers,1052,Service Assistant,35.1052
 3550,35,3000,Food and Beverage Serving Workers,1026,Sommelier,35.1026
-3551,35,9000,Other Food Preparation and Serving Related Workers,1030,Maitre'd,35.1030
+3551,35,9000,Other Food Preparation and Serving Related Workers,1030,Maitre'd,35.103
 3552,35,3000,Food and Beverage Serving Workers,1037,Waitstaff,35.1037
-3553,35,1000,Supervisors of Food Preparation and Serving Workers,1070,Counter Supervisor,35.1070
+3553,35,1000,Supervisors of Food Preparation and Serving Workers,1070,Counter Supervisor,35.107
 3554,35,3000,Food and Beverage Serving Workers,1033,Food Coordinator,35.1033
 3555,35,1000,Supervisors of Food Preparation and Serving Workers,1063,Counter Manager,35.1063
 3556,35,1000,Supervisors of Food Preparation and Serving Workers,1062,Concessions Supervisor,35.1062
@@ -3573,7 +3573,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3571,35,1000,Supervisors of Food Preparation and Serving Workers,1051,General Manager (Food Preparation and Serving Related),35.1051
 3572,35,2000,Cooks and Food Preparation Workers,1028,Food Preparation Worker,35.1028
 3573,35,1000,Supervisors of Food Preparation and Serving Workers,1022,Beverage Manager,35.1022
-3574,37,2000,Building Cleaning and Pest Control Workers,0,Housekeeper,37.0
+3574,37,2000,Building Cleaning and Pest Control Workers,0,Housekeeper,37
 3575,37,2000,Building Cleaning and Pest Control Workers,1,Janitor,37.1
 3576,37,2000,Building Cleaning and Pest Control Workers,2,Environment Services Technician,37.2
 3577,37,2000,Building Cleaning and Pest Control Workers,3,Carpet Cleaning Technician,37.3
@@ -3583,7 +3583,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3581,37,2000,Building Cleaning and Pest Control Workers,7,Sanitation Worker,37.7
 3582,37,3000,Grounds Maintenance Workers,8,Tree Climber (Building and Grounds Cleaning and Maintenance),37.8
 3583,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,9,Housekeeping Supervisor,37.9
-3584,37,2000,Building Cleaning and Pest Control Workers,10,Room Attendant,37.10
+3584,37,2000,Building Cleaning and Pest Control Workers,10,Room Attendant,37.1
 3585,37,2000,Building Cleaning and Pest Control Workers,11,Floor Technician,37.11
 3586,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,12,Housekeeping Manager,37.12
 3587,37,3000,Grounds Maintenance Workers,13,Landscape Laborer,37.13
@@ -3599,7 +3599,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3597,37,2000,Building Cleaning and Pest Control Workers,26,Common Area Attendant,37.26
 3598,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,27,Landscape Supervisor,37.27
 3599,37,3000,Grounds Maintenance Workers,29,Yard Worker,37.29
-3600,37,3000,Grounds Maintenance Workers,30,Irrigation Technician,37.30
+3600,37,3000,Grounds Maintenance Workers,30,Irrigation Technician,37.3
 3601,37,2000,Building Cleaning and Pest Control Workers,31,Porter (Building and Grounds Cleaning and Maintenance),37.31
 3602,37,2000,Building Cleaning and Pest Control Workers,32,Cage Washer Technician,37.32
 3603,37,2000,Building Cleaning and Pest Control Workers,33,Pest Control Specialist,37.33
@@ -3611,18 +3611,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3609,37,2000,Building Cleaning and Pest Control Workers,45,Termite Technician,37.45
 3610,37,3000,Grounds Maintenance Workers,46,Grounds Technician,37.46
 3611,37,2000,Building Cleaning and Pest Control Workers,47,Kitchen Worker (Building and Grounds Cleaning and Maintenance),37.47
-3612,37,2000,Building Cleaning and Pest Control Workers,50,Linen Technician,37.50
+3612,37,2000,Building Cleaning and Pest Control Workers,50,Linen Technician,37.5
 3613,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,54,Landscape Operations Manager,37.54
 3614,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,59,Housekeeping Coordinator,37.59
 3615,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,61,Maintenance Supervisor (Building and Grounds Cleaning and Maintenance),37.61
 3616,37,3000,Grounds Maintenance Workers,69,Tree Trimmer,37.69
-3617,37,3000,Grounds Maintenance Workers,70,Irrigation Specialist,37.70
+3617,37,3000,Grounds Maintenance Workers,70,Irrigation Specialist,37.7
 3618,37,2000,Building Cleaning and Pest Control Workers,75,Housekeeping Room Inspector,37.75
-3619,37,2000,Building Cleaning and Pest Control Workers,80,Turndown Attendant,37.80
+3619,37,2000,Building Cleaning and Pest Control Workers,80,Turndown Attendant,37.8
 3620,37,3000,Grounds Maintenance Workers,94,Pest Route Specialist,37.94
 3621,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,95,Butler (Building and Grounds Cleaning and Maintenance),37.95
 3622,37,2000,Building Cleaning and Pest Control Workers,99,Exterminator,37.99
-3623,37,3000,Grounds Maintenance Workers,100,Arborist (Building and Grounds Cleaning and Maintenance),37.100
+3623,37,3000,Grounds Maintenance Workers,100,Arborist (Building and Grounds Cleaning and Maintenance),37.1
 3624,37,3000,Grounds Maintenance Workers,106,Property Caretaker,37.106
 3625,37,2000,Building Cleaning and Pest Control Workers,116,Floor Worker,37.116
 3626,37,3000,Grounds Maintenance Workers,117,Other Topics,37.117
@@ -3635,8 +3635,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3633,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,30157,Custodian,37.30157
 3634,37,3000,Grounds Maintenance Workers,30837,Independent Contractor (Building and Grounds Cleaning and Maintenance),37.30837
 3635,37,2000,Building Cleaning and Pest Control Workers,31172,Washer (Building and Grounds Cleaning and Maintenance),37.31172
-3636,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,31270,General Supervisor (Building and Grounds Cleaning and Maintenance),37.31270
-3637,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,1080,Grounds Foreman,37.1080
+3636,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,31270,General Supervisor (Building and Grounds Cleaning and Maintenance),37.3127
+3637,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,1080,Grounds Foreman,37.108
 3638,37,3000,Grounds Maintenance Workers,1045,Pesticide Applicator,37.1045
 3639,37,3000,Grounds Maintenance Workers,1056,Tree Surgeon,37.1056
 3640,37,3000,Grounds Maintenance Workers,1007,Mower,37.1007
@@ -3646,15 +3646,15 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3644,37,2000,Building Cleaning and Pest Control Workers,1139,Fumigator,37.1139
 3645,37,3000,Grounds Maintenance Workers,1068,Landscape Specialist,37.1068
 3646,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,1084,Head Landscaper,37.1084
-3647,37,2000,Building Cleaning and Pest Control Workers,1040,Handyman (Building and Grounds Cleaning and Maintenance),37.1040
-3648,37,2000,Building Cleaning and Pest Control Workers,1120,Pest Technician,37.1120
+3647,37,2000,Building Cleaning and Pest Control Workers,1040,Handyman (Building and Grounds Cleaning and Maintenance),37.104
+3648,37,2000,Building Cleaning and Pest Control Workers,1120,Pest Technician,37.112
 3649,37,2000,Building Cleaning and Pest Control Workers,1065,Cleaning Specialist,37.1065
 3650,37,2000,Building Cleaning and Pest Control Workers,1081,Rug Cleaner,37.1081
 3651,37,3000,Grounds Maintenance Workers,1101,Pruner,37.1101
 3652,37,3000,Grounds Maintenance Workers,1071,Horticulture Technician (Building and Grounds Cleaning and Maintenance),37.1071
 3653,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,1026,Grounds Superintendent,37.1026
 3654,37,2000,Building Cleaning and Pest Control Workers,1111,Sexton,37.1111
-3655,37,3000,Grounds Maintenance Workers,1090,Tree Cutter,37.1090
+3655,37,3000,Grounds Maintenance Workers,1090,Tree Cutter,37.109
 3656,37,2000,Building Cleaning and Pest Control Workers,1057,Floor Sweeper,37.1057
 3657,37,3000,Grounds Maintenance Workers,1053,Landscape Horticulturist,37.1053
 3658,37,1000,Supervisors of Building and Grounds Cleaning and Maintenance Workers,1046,Building Supervisor (Building and Grounds Cleaning and Maintenance),37.1046
@@ -3665,7 +3665,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3663,37,2000,Building Cleaning and Pest Control Workers,1015,Bathroom Cleaner,37.1015
 3664,37,3000,Grounds Maintenance Workers,1082,Tree Specialist,37.1082
 3665,37,3000,Grounds Maintenance Workers,1085,Landscape Consultant,37.1085
-3666,39,9000,Other Personal Care and Service Workers,0,Caregiver (Personal Care and Service),39.0
+3666,39,9000,Other Personal Care and Service Workers,0,Caregiver (Personal Care and Service),39
 3667,39,5000,Personal Appearance Workers,1,Salon Manager,39.1
 3668,39,9000,Other Personal Care and Service Workers,2,Activities Assistant (Personal Care and Service),39.2
 3669,39,9000,Other Personal Care and Service Workers,3,Personal Trainer,39.3
@@ -3681,7 +3681,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3679,39,9000,Other Personal Care and Service Workers,17,Homemaker,39.17
 3680,39,9000,Other Personal Care and Service Workers,18,Activities Director (Personal Care and Service),39.18
 3681,39,9000,Other Personal Care and Service Workers,19,Activities Coordinator,39.19
-3682,39,5000,Personal Appearance Workers,20,Nail Technician,39.20
+3682,39,5000,Personal Appearance Workers,20,Nail Technician,39.2
 3683,39,7000,Tour and Travel Guides,21,Event Staffer,39.21
 3684,39,9000,Other Personal Care and Service Workers,23,Activities Aide,39.23
 3685,39,9000,Other Personal Care and Service Workers,25,Recreation Assistant,39.25
@@ -3689,7 +3689,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3687,39,9000,Other Personal Care and Service Workers,27,Group Fitness Instructor,39.27
 3688,39,5000,Personal Appearance Workers,28,Beauty Advisor,39.28
 3689,39,9000,Other Personal Care and Service Workers,29,Nursery Worker (Personal Care and Service),39.29
-3690,39,9000,Other Personal Care and Service Workers,30,Personal Care Attendant,39.30
+3690,39,9000,Other Personal Care and Service Workers,30,Personal Care Attendant,39.3
 3691,39,9000,Other Personal Care and Service Workers,31,Recreation Specialist,39.31
 3692,39,9000,Other Personal Care and Service Workers,32,Child Life Specialist,39.32
 3693,39,9000,Other Personal Care and Service Workers,34,Recreation Aide,39.34
@@ -3697,7 +3697,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3695,39,4000,Funeral Service Workers,36,Funeral Assistant,39.36
 3696,39,5000,Personal Appearance Workers,38,Hairdresser,39.38
 3697,39,2000,Animal Care and Service Workers,39,Pet Groomer,39.39
-3698,39,9000,Other Personal Care and Service Workers,40,Nanny,39.40
+3698,39,9000,Other Personal Care and Service Workers,40,Nanny,39.4
 3699,39,9000,Other Personal Care and Service Workers,41,Activities Leader,39.41
 3700,39,1000,Supervisors of Personal Care and Service Workers,42,Spa Manager,39.42
 3701,39,9000,Other Personal Care and Service Workers,43,Recreation Director,39.43
@@ -3709,21 +3709,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3707,39,9000,Other Personal Care and Service Workers,54,Skin Care Instructor,39.54
 3708,39,9000,Other Personal Care and Service Workers,55,Child Care Attendant,39.55
 3709,39,5000,Personal Appearance Workers,58,Barber,39.58
-3710,39,3000,Entertainment Attendants and Related Workers,60,Usher,39.60
+3710,39,3000,Entertainment Attendants and Related Workers,60,Usher,39.6
 3711,39,3000,Entertainment Attendants and Related Workers,62,Wardrobe Attendant,39.62
 3712,39,3000,Entertainment Attendants and Related Workers,63,Gate Attendant,39.63
 3713,39,9000,Other Personal Care and Service Workers,64,Fitness Consultant,39.64
 3714,39,9000,Other Personal Care and Service Workers,65,Child Care Assistant,39.65
 3715,39,9000,Other Personal Care and Service Workers,67,Yoga Instructor,39.67
 3716,39,9000,Other Personal Care and Service Workers,69,Beauty Skin Care Consultant,39.69
-3717,39,1000,Supervisors of Personal Care and Service Workers,70,Theater Supervisor,39.70
+3717,39,1000,Supervisors of Personal Care and Service Workers,70,Theater Supervisor,39.7
 3718,39,9000,Other Personal Care and Service Workers,74,Assisted Living Supervisor,39.74
 3719,39,9000,Other Personal Care and Service Workers,75,Housekeeping Aide,39.75
 3720,39,4000,Funeral Service Workers,76,Embalmer,39.76
 3721,39,9000,Other Personal Care and Service Workers,77,Sitter,39.77
 3722,39,5000,Personal Appearance Workers,78,Manicurist,39.78
 3723,39,2000,Animal Care and Service Workers,79,Stable Attendant,39.79
-3724,39,9000,Other Personal Care and Service Workers,80,Master Fitness Trainer,39.80
+3724,39,9000,Other Personal Care and Service Workers,80,Master Fitness Trainer,39.8
 3725,39,9000,Other Personal Care and Service Workers,81,Life Skills Trainer,39.81
 3726,39,9000,Other Personal Care and Service Workers,82,Life Enrichment Assistant (Personal Care and Service),39.82
 3727,39,1000,Supervisors of Personal Care and Service Workers,84,Table Games Floor Supervisor,39.84
@@ -3731,13 +3731,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3729,39,9000,Other Personal Care and Service Workers,86,Utility Aide,39.86
 3730,39,3000,Entertainment Attendants and Related Workers,88,Event Attendant,39.88
 3731,39,9000,Other Personal Care and Service Workers,89,Recreation Leader,39.89
-3732,39,9000,Other Personal Care and Service Workers,90,Fitness Coach,39.90
+3732,39,9000,Other Personal Care and Service Workers,90,Fitness Coach,39.9
 3733,39,9000,Other Personal Care and Service Workers,92,Valet,39.92
 3734,39,1000,Supervisors of Personal Care and Service Workers,95,Slot Service Specialist,39.95
 3735,39,9000,Other Personal Care and Service Workers,97,Personal Care Coordinator,39.97
 3736,39,3000,Entertainment Attendants and Related Workers,98,Golf Caddie,39.98
 3737,39,2000,Animal Care and Service Workers,99,Dog Groomer,39.99
-3738,39,9000,Other Personal Care and Service Workers,100,Dog Walker,39.100
+3738,39,9000,Other Personal Care and Service Workers,100,Dog Walker,39.1
 3739,39,9000,Other Personal Care and Service Workers,101,Butler (Personal Care and Service),39.101
 3740,39,3000,Entertainment Attendants and Related Workers,102,Recreation Attendant,39.102
 3741,39,9000,Other Personal Care and Service Workers,103,Recreation Manager,39.103
@@ -3746,7 +3746,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3744,39,3000,Entertainment Attendants and Related Workers,106,Casino Dealer,39.106
 3745,39,5000,Personal Appearance Workers,108,Hair Stylist Assistant,39.108
 3746,39,2000,Animal Care and Service Workers,109,Caretaker,39.109
-3747,39,3000,Entertainment Attendants and Related Workers,110,Projectionist,39.110
+3747,39,3000,Entertainment Attendants and Related Workers,110,Projectionist,39.11
 3748,39,6000,"Baggage Porters, Bellhops, and Concierges",111,Doorman,39.111
 3749,39,9000,Other Personal Care and Service Workers,112,Aquatics Director (Personal Care and Services),39.112
 3750,39,3000,Entertainment Attendants and Related Workers,713,Other Topics,39.713
@@ -3778,7 +3778,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3776,39,9000,Other Personal Care and Service Workers,1028,Group Leader,39.1028
 3777,39,3000,Entertainment Attendants and Related Workers,1168,Piercer,39.1168
 3778,39,3000,Entertainment Attendants and Related Workers,1096,Wardrobe Assistant,39.1096
-3779,39,1000,Supervisors of Personal Care and Service Workers,1120,Game Supervisor,39.1120
+3779,39,1000,Supervisors of Personal Care and Service Workers,1120,Game Supervisor,39.112
 3780,39,9000,Other Personal Care and Service Workers,1133,Sports Instructor,39.1133
 3781,39,2000,Animal Care and Service Workers,1155,Farrier,39.1155
 3782,39,2000,Animal Care and Service Workers,1026,Zoo Keeper,39.1026
@@ -3791,7 +3791,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3789,39,9000,Other Personal Care and Service Workers,1004,Camp Counselor,39.1004
 3790,39,3000,Entertainment Attendants and Related Workers,1045,Docent,39.1045
 3791,39,6000,"Baggage Porters, Bellhops, and Concierges",1173,Stewardess,39.1173
-3792,39,9000,Other Personal Care and Service Workers,1150,Fitness Director,39.1150
+3792,39,9000,Other Personal Care and Service Workers,1150,Fitness Director,39.115
 3793,39,9000,Other Personal Care and Service Workers,1125,Pilates Teacher,39.1125
 3794,39,9000,Other Personal Care and Service Workers,1098,Recreational Leader,39.1098
 3795,39,7000,Tour and Travel Guides,1087,Tour Operator,39.1087
@@ -3804,7 +3804,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3802,39,9000,Other Personal Care and Service Workers,1014,Child Care Provider,39.1014
 3803,39,5000,Personal Appearance Workers,1132,Skincare Consultant,39.1132
 3804,39,2000,Animal Care and Service Workers,1182,Aquarist,39.1182
-3805,39,1000,Supervisors of Personal Care and Service Workers,1070,Personal Manager,39.1070
+3805,39,1000,Supervisors of Personal Care and Service Workers,1070,Personal Manager,39.107
 3806,39,6000,"Baggage Porters, Bellhops, and Concierges",1124,Steward (Personal Care and Service),39.1124
 3807,39,1000,Supervisors of Personal Care and Service Workers,1109,Costume Supervisor,39.1109
 3808,39,9000,Other Personal Care and Service Workers,1112,Wax Specialist,39.1112
@@ -3818,7 +3818,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3816,39,9000,Other Personal Care and Service Workers,1032,Camp Coordinator,39.1032
 3817,39,9000,Other Personal Care and Service Workers,1055,Au Pair,39.1055
 3818,39,9000,Other Personal Care and Service Workers,1115,House Sitter,39.1115
-3819,39,2000,Animal Care and Service Workers,1060,Animal Keeper,39.1060
+3819,39,2000,Animal Care and Service Workers,1060,Animal Keeper,39.106
 3820,39,5000,Personal Appearance Workers,1179,Outfitter,39.1179
 3821,39,9000,Other Personal Care and Service Workers,1027,Trip Leader,39.1027
 3822,39,6000,"Baggage Porters, Bellhops, and Concierges",1192,Tattooist,39.1192
@@ -3829,14 +3829,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3827,39,9000,Other Personal Care and Service Workers,1011,Strength and Conditioning Coach,39.1011
 3828,39,2000,Animal Care and Service Workers,1113,Pet Sitter,39.1113
 3829,39,5000,Personal Appearance Workers,1006,Beauty Consultant,39.1006
-3830,39,7000,Tour and Travel Guides,1100,Interpreter (Personal Care and Service),39.1100
+3830,39,7000,Tour and Travel Guides,1100,Interpreter (Personal Care and Service),39.11
 3831,39,9000,Other Personal Care and Service Workers,1056,Camp Leader,39.1056
 3832,39,9000,Other Personal Care and Service Workers,1076,Camp Instructor,39.1076
 3833,39,9000,Other Personal Care and Service Workers,1041,Zumba Instructor,39.1041
 3834,39,3000,Entertainment Attendants and Related Workers,1049,Costume Designer,39.1049
 3835,39,9000,Other Personal Care and Service Workers,1121,Fitness Coordinator,39.1121
 3836,39,9000,Other Personal Care and Service Workers,1221,Head of Strength and Conditioning,39.1221
-3837,41,2000,Retail Sales Workers,0,Cashier (Sales and Related),41.0
+3837,41,2000,Retail Sales Workers,0,Cashier (Sales and Related),41
 3838,41,2000,Retail Sales Workers,1,Retail Sales Associate,41.1
 3839,41,4000,"Sales Representatives, Wholesale and Manufacturing",2,Sales Representative,41.2
 3840,41,1000,Supervisors of Sales Workers,3,Assistant Store Manager (Sales and Related),41.3
@@ -3846,7 +3846,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3844,41,3000,"Sales Representatives, Services",7,Brand Ambassador,41.7
 3845,41,3000,"Sales Representatives, Services",8,Account Executive (Sales and Related),41.8
 3846,41,4000,"Sales Representatives, Wholesale and Manufacturing",9,Automotive Sales Representative,41.9
-3847,41,1000,Supervisors of Sales Workers,10,Sales Supervisor,41.10
+3847,41,1000,Supervisors of Sales Workers,10,Sales Supervisor,41.1
 3848,41,3000,"Sales Representatives, Services",12,Account Manager (Sales and Related),41.12
 3849,41,1000,Supervisors of Sales Workers,13,Sales Management Trainee (Sales and Related),41.13
 3850,41,3000,"Sales Representatives, Services",14,Inside Sales Representative,41.14
@@ -3874,7 +3874,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3872,41,4000,"Sales Representatives, Wholesale and Manufacturing",45,B2B Sales Consultant,41.45
 3873,41,3000,"Sales Representatives, Services",46,Banking Sales Representative,41.46
 3874,41,3000,"Sales Representatives, Services",48,Business Banker,41.48
-3875,41,2000,Retail Sales Workers,50,Event Sales Associate,41.50
+3875,41,2000,Retail Sales Workers,50,Event Sales Associate,41.5
 3876,41,2000,Retail Sales Workers,52,Sales Clerk,41.52
 3877,41,3000,"Sales Representatives, Services",53,Phone Banker,41.53
 3878,41,3000,"Sales Representatives, Services",54,Relationship Banker,41.54
@@ -3894,7 +3894,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3892,41,3000,"Sales Representatives, Services",76,Travel Agent,41.76
 3893,41,4000,"Sales Representatives, Wholesale and Manufacturing",77,Clinical Sales Consultant,41.77
 3894,41,4000,"Sales Representatives, Wholesale and Manufacturing",79,Medical Sales Representative,41.79
-3895,41,4000,"Sales Representatives, Wholesale and Manufacturing",80,Call Center Sales Representative,41.80
+3895,41,4000,"Sales Representatives, Wholesale and Manufacturing",80,Call Center Sales Representative,41.8
 3896,41,4000,"Sales Representatives, Wholesale and Manufacturing",81,Product Sales Specialist,41.81
 3897,41,4000,"Sales Representatives, Wholesale and Manufacturing",83,Internet Sales Representative,41.83
 3898,41,3000,"Sales Representatives, Services",84,B2B Sales Representative,41.84
@@ -3921,7 +3921,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3919,41,4000,"Sales Representatives, Wholesale and Manufacturing",30446,Retail Cosmetics Sales Beauty Advisor,41.30446
 3920,41,2000,Retail Sales Workers,10377,Retail Consultant,41.10377
 3921,41,2000,Retail Sales Workers,30942,Retail Clerk,41.30942
-3922,41,9000,Other Sales and Related Workers,11420,Realtor,41.11420
+3922,41,9000,Other Sales and Related Workers,11420,Realtor,41.1142
 3923,41,3000,"Sales Representatives, Services",30812,Professional Services Consultant,41.30812
 3924,41,3000,"Sales Representatives, Services",30543,Mobile Consultant,41.30543
 3925,41,2000,Retail Sales Workers,31452,Merchandising Assistant,41.31452
@@ -3934,11 +3934,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3932,41,4000,"Sales Representatives, Wholesale and Manufacturing",30359,Direct Sales Representative,41.30359
 3933,41,4000,"Sales Representatives, Wholesale and Manufacturing",31116,Customer Sales Distributor,41.31116
 3934,41,2000,Retail Sales Workers,30779,Courtesy Clerk,41.30779
-3935,41,3000,"Sales Representatives, Services",30270,Campus Representative,41.30270
+3935,41,3000,"Sales Representatives, Services",30270,Campus Representative,41.3027
 3936,41,3000,"Sales Representatives, Services",31079,Advertising Sales Executive,41.31079
 3937,41,3000,"Sales Representatives, Services",30981,Account Liaison,41.30981
-3938,41,3000,"Sales Representatives, Services",10310,Account Leader,41.10310
-3939,41,2000,Retail Sales Workers,30020,Retail Sales Consultant,41.30020
+3938,41,3000,"Sales Representatives, Services",10310,Account Leader,41.1031
+3939,41,2000,Retail Sales Workers,30020,Retail Sales Consultant,41.3002
 3940,41,1000,Supervisors of Sales Workers,31003,Merchandising Supervisor,41.31003
 3941,41,4000,"Sales Representatives, Wholesale and Manufacturing",31081,Merchandising Representative,41.31081
 3942,41,9000,Other Sales and Related Workers,30991,Leasing Agent,41.30991
@@ -3951,9 +3951,9 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3949,41,3000,"Sales Representatives, Services",31017,Travel Counselor (Sales and Related),41.31017
 3950,41,3000,"Sales Representatives, Services",31093,Travel Consultant (Sales and Related),41.31093
 3951,41,3000,"Sales Representatives, Services",10603,Trading Analyst (Sales and Related),41.10603
-3952,41,3000,"Sales Representatives, Services",10270,Trader (Sales and Related),41.10270
+3952,41,3000,"Sales Representatives, Services",10270,Trader (Sales and Related),41.1027
 3953,41,2000,Retail Sales Workers,30007,Teller (Sales and Related),41.30007
-3954,41,1000,Supervisors of Sales Workers,10390,Shop Manager (Sales and Related),41.10390
+3954,41,1000,Supervisors of Sales Workers,10390,Shop Manager (Sales and Related),41.1039
 3955,41,2000,Retail Sales Workers,31564,Selling Manager (Sales and Related),41.31564
 3956,41,1000,Supervisors of Sales Workers,30613,Program Supervisor (Sales and Related),41.30613
 3957,41,3000,"Sales Representatives, Services",30158,Personal Financial Representative (Sales and Related),41.30158
@@ -3974,7 +3974,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3972,41,2000,Retail Sales Workers,11058,Shop Assistant (Sales and Related),41.11058
 3973,41,4000,"Sales Representatives, Wholesale and Manufacturing",10364,Sales Officer (Sales and Related),41.10364
 3974,41,9000,Other Sales and Related Workers,30837,Independent Contractor (Sales and Related),41.30837
-3975,41,1000,Supervisors of Sales Workers,31270,General Supervisor (Sales and Related),41.31270
+3975,41,1000,Supervisors of Sales Workers,31270,General Supervisor (Sales and Related),41.3127
 3976,41,2000,Retail Sales Workers,30214,Food Clerk (Sales and Related),41.30214
 3977,41,3000,"Sales Representatives, Services",30162,Financial Services Representative (Sales and Related),41.30162
 3978,41,9000,Other Sales and Related Workers,10196,Field Representative (Sales and Related),41.10196
@@ -3993,7 +3993,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 3991,41,3000,"Sales Representatives, Services",1105,Head of Equities,41.1105
 3992,41,9000,Other Sales and Related Workers,1026,Model,41.1026
 3993,41,2000,Retail Sales Workers,1084,Customer Assistant,41.1084
-3994,41,1000,Supervisors of Sales Workers,1020,Service Manager,41.1020
+3994,41,1000,Supervisors of Sales Workers,1020,Service Manager,41.102
 3995,41,9000,Other Sales and Related Workers,1024,Sales Agent,41.1024
 3996,41,1000,Supervisors of Sales Workers,1045,Key Holder,41.1045
 3997,41,3000,"Sales Representatives, Services",1051,Product Specialist (Sales and Related),41.1051
@@ -4007,13 +4007,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4005,41,9000,Other Sales and Related Workers,1073,Demonstrator,41.1073
 4006,41,4000,"Sales Representatives, Wholesale and Manufacturing",1074,Sales Merchandiser,41.1074
 4007,41,3000,"Sales Representatives, Services",1008,Broker,41.1008
-4008,41,3000,"Sales Representatives, Services",1110,Investment Representative,41.1110
+4008,41,3000,"Sales Representatives, Services",1110,Investment Representative,41.111
 4009,41,3000,"Sales Representatives, Services",1195,Insurance Manager,41.1195
 4010,41,1000,Supervisors of Sales Workers,1152,Area Manager (Sales and Related),41.1152
 4011,41,3000,"Sales Representatives, Services",1069,Financial Advisor (Sales and Related),41.1069
 4012,41,4000,"Sales Representatives, Wholesale and Manufacturing",1065,Marketing Representative (Sales and Related),41.1065
 4013,41,4000,"Sales Representatives, Wholesale and Manufacturing",1062,Head of Sales (Sales and Related),41.1062
-4014,41,9000,Other Sales and Related Workers,1160,Negotiator (Sales and Related),41.1160
+4014,41,9000,Other Sales and Related Workers,1160,Negotiator (Sales and Related),41.116
 4015,41,4000,"Sales Representatives, Wholesale and Manufacturing",1022,Salesman,41.1022
 4016,41,4000,"Sales Representatives, Wholesale and Manufacturing",1006,Sales Executive (Sales and Related),41.1006
 4017,41,3000,"Sales Representatives, Services",1028,Insurance Agent,41.1028
@@ -4023,7 +4023,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4021,41,9000,Other Sales and Related Workers,1021,Promoter (Sales and Related),41.1021
 4022,41,1000,Supervisors of Sales Workers,1146,Sales Leader (Sales and Related),41.1146
 4023,41,1000,Supervisors of Sales Workers,1036,Retail Manager,41.1036
-4024,43,4000,Information and Record Clerks,0,Customer Service Representative (Office and Administrative Support),43.0
+4024,43,4000,Information and Record Clerks,0,Customer Service Representative (Office and Administrative Support),43
 4025,43,4000,Information and Record Clerks,1,Administrative Assistant,43.1
 4026,43,3000,Financial Clerks,2,Bank Teller,43.2
 4027,43,3000,Financial Clerks,3,Bookkeeper,43.3
@@ -4033,7 +4033,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4031,43,9000,Other Office and Administrative Support Workers,7,Data Entry Clerk,43.7
 4032,43,9000,Other Office and Administrative Support Workers,8,Receptionist,43.8
 4033,43,3000,Financial Clerks,9,Accounts Payable Clerk,43.9
-4034,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",10,Warehouse Worker (Office and Administrative Support),43.10
+4034,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",10,Warehouse Worker (Office and Administrative Support),43.1
 4035,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",11,Stockroom Associate,43.11
 4036,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",12,Replenishment Associate,43.12
 4037,43,4000,Information and Record Clerks,13,Customer Account Representative,43.13
@@ -4043,7 +4043,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4041,43,3000,Financial Clerks,17,Collections Specialist,43.17
 4042,43,6000,Secretaries and Administrative Assistants,18,Legal Secretary,43.18
 4043,43,9000,Other Office and Administrative Support Workers,19,General Office Clerk,43.19
-4044,43,9000,Other Office and Administrative Support Workers,20,Merchandise Support Associate,43.20
+4044,43,9000,Other Office and Administrative Support Workers,20,Merchandise Support Associate,43.2
 4045,43,4000,Information and Record Clerks,21,Automotive Sales Service Advisor,43.21
 4046,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",22,Warehouse Associate,43.22
 4047,43,3000,Financial Clerks,23,Payroll Specialist,43.23
@@ -4053,7 +4053,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4051,43,6000,Secretaries and Administrative Assistants,27,Office Administrator,43.27
 4052,43,3000,Financial Clerks,28,Medical Biller,43.28
 4053,43,1000,Supervisors of Office and Administrative Support Workers,29,Customer Service Supervisor,43.29
-4054,43,1000,Supervisors of Office and Administrative Support Workers,30,Payroll Administrator,43.30
+4054,43,1000,Supervisors of Office and Administrative Support Workers,30,Payroll Administrator,43.3
 4055,43,4000,Information and Record Clerks,31,Customer Service Specialist,43.31
 4056,43,3000,Financial Clerks,32,Accounting Assistant,43.32
 4057,43,4000,Information and Record Clerks,33,Front Desk Coordinator,43.33
@@ -4063,7 +4063,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4061,43,9000,Other Office and Administrative Support Workers,37,Administrative Clerk,43.37
 4062,43,3000,Financial Clerks,38,Patient Service Representative (Office and Administrative Support),43.38
 4063,43,3000,Financial Clerks,39,Billing Clerk,43.39
-4064,43,6000,Secretaries and Administrative Assistants,40,Administrative Coordinator,43.40
+4064,43,6000,Secretaries and Administrative Assistants,40,Administrative Coordinator,43.4
 4065,43,4000,Information and Record Clerks,41,Loan Closer,43.41
 4066,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",42,Shipping and Receiving Clerk,43.42
 4067,43,9000,Other Office and Administrative Support Workers,43,Office Coordinator,43.43
@@ -4071,13 +4071,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4069,43,9000,Other Office and Administrative Support Workers,46,Project Assistant,43.46
 4070,43,3000,Financial Clerks,48,Account Coordinator (Office and Administrative Support),43.48
 4071,43,3000,Financial Clerks,49,Collector,43.49
-4072,43,4000,Information and Record Clerks,50,Customer Engagement Specialist,43.50
+4072,43,4000,Information and Record Clerks,50,Customer Engagement Specialist,43.5
 4073,43,4000,Information and Record Clerks,51,Client Service Coordinator,43.51
 4074,43,4000,Information and Record Clerks,52,Human Resources (HR) Coordinator (Office and Administrative Support),43.52
 4075,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",53,Inventory Clerk,43.53
 4076,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",55,Inventory Control Specialist,43.55
 4077,43,4000,Information and Record Clerks,58,Mortgage Closer (Office and Administrative Support),43.58
-4078,43,4000,Information and Record Clerks,60,Customer Care Specialist,43.60
+4078,43,4000,Information and Record Clerks,60,Customer Care Specialist,43.6
 4079,43,6000,Secretaries and Administrative Assistants,61,Office Assistant,43.61
 4080,43,9000,Other Office and Administrative Support Workers,62,Claims Processor,43.62
 4081,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",63,Material Handler (Office and Administrative Support),43.63
@@ -4087,7 +4087,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4085,43,9000,Other Office and Administrative Support Workers,67,Claims Representative,43.67
 4086,43,9000,Other Office and Administrative Support Workers,68,Escrow Assistant (Office and Administrative Support),43.68
 4087,43,9000,Other Office and Administrative Support Workers,69,Computer Operator,43.69
-4088,43,1000,Supervisors of Office and Administrative Support Workers,70,Call Center Supervisor,43.70
+4088,43,1000,Supervisors of Office and Administrative Support Workers,70,Call Center Supervisor,43.7
 4089,43,4000,Information and Record Clerks,72,Front Office Specialist,43.72
 4090,43,3000,Financial Clerks,73,Accounting Associate,43.73
 4091,43,4000,Information and Record Clerks,74,Customer Greeter,43.74
@@ -4096,7 +4096,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4094,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",77,Production Planner,43.77
 4095,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",78,Grocery Associate,43.78
 4096,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",79,Scheduler,43.79
-4097,43,4000,Information and Record Clerks,80,Patient Access Representative,43.80
+4097,43,4000,Information and Record Clerks,80,Patient Access Representative,43.8
 4098,43,3000,Financial Clerks,81,Patient Account Representative,43.81
 4099,43,4000,Information and Record Clerks,82,Post Closer,43.82
 4100,43,4000,Information and Record Clerks,83,Mortgage Specialist (Office and Administrative Support),43.83
@@ -4112,7 +4112,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4110,43,4000,Information and Record Clerks,95,Technical Services Associate,43.95
 4111,43,9000,Other Office and Administrative Support Workers,96,Account Administrator,43.96
 4112,43,6000,Secretaries and Administrative Assistants,99,Billing Coordinator,43.99
-4113,43,1000,Supervisors of Office and Administrative Support Workers,100,Accounts Payable Supervisor,43.100
+4113,43,1000,Supervisors of Office and Administrative Support Workers,100,Accounts Payable Supervisor,43.1
 4114,43,4000,Information and Record Clerks,101,Loan Documentation Specialist,43.101
 4115,43,9000,Other Office and Administrative Support Workers,102,Claims Specialist (Office and Administrative Support),43.102
 4116,43,4000,Information and Record Clerks,104,Loan Servicing Specialist,43.104
@@ -4120,21 +4120,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4118,43,9000,Other Office and Administrative Support Workers,106,Clerical Assistant,43.106
 4119,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",107,Pricing Coordinator,43.107
 4120,43,9000,Other Office and Administrative Support Workers,108,Medical Collector,43.108
-4121,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",110,Dispatcher (Office and Administrative Support),43.110
+4121,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",110,Dispatcher (Office and Administrative Support),43.11
 4122,43,6000,Secretaries and Administrative Assistants,111,Administrative Associate,43.111
 4123,43,3000,Financial Clerks,112,Billing Representative,43.112
 4124,43,4000,Information and Record Clerks,115,Admissions Coordinator (Office and Administrative Support),43.115
 4125,43,9000,Other Office and Administrative Support Workers,117,Insurance Specialist,43.117
 4126,43,4000,Information and Record Clerks,118,Mortgage Assistant (Office and Administrative Support),43.118
 4127,43,6000,Secretaries and Administrative Assistants,119,Medical Secretary,43.119
-4128,43,4000,Information and Record Clerks,120,Bilingual Receptionist,43.120
+4128,43,4000,Information and Record Clerks,120,Bilingual Receptionist,43.12
 4129,43,4000,Information and Record Clerks,122,Admissions Representative (Office and Administrative Support),43.122
 4130,43,9000,Other Office and Administrative Support Workers,123,Claims Assistant,43.123
 4131,43,1000,Supervisors of Office and Administrative Support Workers,124,Collections Supervisor,43.124
 4132,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",125,Order Selector,43.125
 4133,43,3000,Financial Clerks,127,Billing Analyst (Office and Administrative Support),43.127
 4134,43,4000,Information and Record Clerks,129,Mortgage Processor,43.129
-4135,43,4000,Information and Record Clerks,130,Field Service Representative,43.130
+4135,43,4000,Information and Record Clerks,130,Field Service Representative,43.13
 4136,43,9000,Other Office and Administrative Support Workers,131,Foreclosure Claims Specialist,43.131
 4137,43,3000,Financial Clerks,132,Accounts Payable Processor,43.132
 4138,43,3000,Financial Clerks,133,Payroll Processor,43.133
@@ -4143,7 +4143,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4141,43,4000,Information and Record Clerks,136,Switchboard Operator,43.136
 4142,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",137,Logistics Clerk,43.137
 4143,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",138,Material Planner,43.138
-4144,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",140,Shipping and Receiving Associate,43.140
+4144,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",140,Shipping and Receiving Associate,43.14
 4145,43,4000,Information and Record Clerks,141,Credit Specialist,43.141
 4146,43,4000,Information and Record Clerks,143,Recruiting Assistant,43.143
 4147,43,4000,Information and Record Clerks,144,Transaction Processor,43.144
@@ -4151,7 +4151,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4149,43,6000,Secretaries and Administrative Assistants,146,Personal Assistant (Office and Administrative Support),43.146
 4150,43,9000,Other Office and Administrative Support Workers,148,Purchasing Clerk,43.148
 4151,43,6000,Secretaries and Administrative Assistants,149,Executive Administrative Assistant,43.149
-4152,43,1000,Supervisors of Office and Administrative Support Workers,150,Payroll Supervisor,43.150
+4152,43,1000,Supervisors of Office and Administrative Support Workers,150,Payroll Supervisor,43.15
 4153,43,4000,Information and Record Clerks,151,Title Clerk (Office and Administrative Support),43.151
 4154,43,6000,Secretaries and Administrative Assistants,152,Patient Coordinator,43.152
 4155,43,3000,Financial Clerks,153,Accounts Receivable Representative,43.153
@@ -4160,21 +4160,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4158,43,4000,Information and Record Clerks,156,Client Service Specialist (Office and Administrative Support),43.156
 4159,43,4000,Information and Record Clerks,157,Credit Collections Analyst,43.157
 4160,43,3000,Financial Clerks,158,Purchasing Assistant,43.158
-4161,43,9000,Other Office and Administrative Support Workers,160,Underwriting Assistant,43.160
+4161,43,9000,Other Office and Administrative Support Workers,160,Underwriting Assistant,43.16
 4162,43,3000,Financial Clerks,161,Collections Clerk,43.161
 4163,43,3000,Financial Clerks,163,Payment Poster,43.163
 4164,43,1000,Supervisors of Office and Administrative Support Workers,164,Claims Supervisor,43.164
 4165,43,4000,Information and Record Clerks,165,Customer Service Advisor (Office and Administrative Support),43.165
 4166,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",167,Material Coordinator,43.167
 4167,43,1000,Supervisors of Office and Administrative Support Workers,168,Office Supervisor,43.168
-4168,43,6000,Secretaries and Administrative Assistants,170,Administrative Secretary,43.170
+4168,43,6000,Secretaries and Administrative Assistants,170,Administrative Secretary,43.17
 4169,43,9000,Other Office and Administrative Support Workers,172,Medical Office Assistant,43.172
 4170,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",173,Inventory Coordinator,43.173
 4171,43,4000,Information and Record Clerks,178,Credit Representative,43.178
 4172,43,3000,Financial Clerks,179,Payroll Assistant,43.179
 4173,43,4000,Information and Record Clerks,182,Office Associate,43.182
 4174,43,4000,Information and Record Clerks,186,Interviewer,43.186
-4175,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",190,Shipper,43.190
+4175,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",190,Shipper,43.19
 4176,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",192,Expeditor,43.192
 4177,43,4000,Information and Record Clerks,194,Customer Service Associate (Office and Administrative Support),43.194
 4178,43,6000,Secretaries and Administrative Assistants,195,Litigation Secretary,43.195
@@ -4185,21 +4185,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4183,43,9000,Other Office and Administrative Support Workers,205,Loan Assistant,43.205
 4184,43,4000,Information and Record Clerks,213,Customer Service Assistant,43.213
 4185,43,4000,Information and Record Clerks,218,Client Representative (Office and Administrative Support),43.218
-4186,43,6000,Secretaries and Administrative Assistants,220,Project Administrative Staff,43.220
+4186,43,6000,Secretaries and Administrative Assistants,220,Project Administrative Staff,43.22
 4187,43,9000,Other Office and Administrative Support Workers,232,Other Topics,43.232
 4188,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",10701,Records Clerk,43.10701
 4189,43,2000,Communications Equipment Operators,30784,Private Branch Exchange (PBX) Operator,43.30784
-4190,43,4000,Information and Record Clerks,31080,Guest Services Manager,43.31080
+4190,43,4000,Information and Record Clerks,31080,Guest Services Manager,43.3108
 4191,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30912,Warehouse Technician,43.30912
 4192,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",10657,Warehouse Assistant,43.10657
 4193,43,9000,Other Office and Administrative Support Workers,10731,Typist,43.10731
 4194,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31142,Systems Clerk,43.31142
-4195,43,9000,Other Office and Administrative Support Workers,30910,Support Clerk,43.30910
+4195,43,9000,Other Office and Administrative Support Workers,30910,Support Clerk,43.3091
 4196,43,6000,Secretaries and Administrative Assistants,31215,Specialist Assistant,43.31215
 4197,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31005,Shipping Clerk,43.31005
 4198,43,9000,Other Office and Administrative Support Workers,10039,Secretary (Office and Administrative Support),43.10039
 4199,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31354,Scheduler Planner,43.31354
-4200,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30930,Review Coordinator,43.30930
+4200,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30930,Review Coordinator,43.3093
 4201,43,9000,Other Office and Administrative Support Workers,11698,Resource Assistant,43.11698
 4202,43,4000,Information and Record Clerks,30342,Registration Representative,43.30342
 4203,43,9000,Other Office and Administrative Support Workers,10923,Real Estate Assistant,43.10923
@@ -4229,14 +4229,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4227,43,9000,Other Office and Administrative Support Workers,10465,Financial Assistant,43.10465
 4228,43,6000,Secretaries and Administrative Assistants,31188,Executive Secretary,43.31188
 4229,43,6000,Secretaries and Administrative Assistants,31204,Department Secretary,43.31204
-4230,43,3000,Financial Clerks,30290,Debt Collector,43.30290
-4231,43,9000,Other Office and Administrative Support Workers,30810,Customer Service Technician,43.30810
+4230,43,3000,Financial Clerks,30290,Debt Collector,43.3029
+4231,43,9000,Other Office and Administrative Support Workers,30810,Customer Service Technician,43.3081
 4232,43,4000,Information and Record Clerks,10623,Customer Service Leader,43.10623
 4233,43,4000,Information and Record Clerks,30757,Customer Service Coordinator,43.30757
 4234,43,1000,Supervisors of Office and Administrative Support Workers,30987,Customer Care Manager,43.30987
 4235,43,4000,Information and Record Clerks,30756,Customer Care Assistant,43.30756
 4236,43,3000,Financial Clerks,10836,Collections Analyst,43.10836
-4237,43,1000,Supervisors of Office and Administrative Support Workers,31360,Branch Supervisor,43.31360
+4237,43,1000,Supervisors of Office and Administrative Support Workers,31360,Branch Supervisor,43.3136
 4238,43,6000,Secretaries and Administrative Assistants,30302,Branch Office Administrator,43.30302
 4239,43,1000,Supervisors of Office and Administrative Support Workers,11088,Branch Administrator,43.11088
 4240,43,3000,Financial Clerks,11004,Billing Assistant,43.11004
@@ -4248,28 +4248,28 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4246,43,4000,Information and Record Clerks,30904,Registration Clerk,43.30904
 4247,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31284,Project Scheduler,43.31284
 4248,43,9000,Other Office and Administrative Support Workers,31119,Processing Clerk,43.31119
-4249,43,4000,Information and Record Clerks,10610,Patient Liaison,43.10610
+4249,43,4000,Information and Record Clerks,10610,Patient Liaison,43.1061
 4250,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31173,Order Picker,43.31173
 4251,43,9000,Other Office and Administrative Support Workers,10182,Operations Assistant (Office and Administrative Support),43.10182
 4252,43,4000,Information and Record Clerks,10718,Medical Representative,43.10718
-4253,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30950,Materials Controller,43.30950
+4253,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30950,Materials Controller,43.3095
 4254,43,4000,Information and Record Clerks,11209,Loan Coordinator,43.11209
-4255,43,9000,Other Office and Administrative Support Workers,30980,Insurance Assistant,43.30980
-4256,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30170,General Merchandise Clerk,43.30170
+4255,43,9000,Other Office and Administrative Support Workers,30980,Insurance Assistant,43.3098
+4256,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30170,General Merchandise Clerk,43.3017
 4257,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31046,Distribution Technician,43.31046
 4258,43,4000,Information and Record Clerks,30827,Customer Service Officer,43.30827
 4259,43,4000,Information and Record Clerks,31236,Customer Service Desk,43.31236
 4260,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",11055,Clinical Scheduler,43.11055
 4261,43,4000,Information and Record Clerks,30081,Clinic Coordinator,43.30081
 4262,43,4000,Information and Record Clerks,11176,Client Service Officer,43.11176
-4263,43,1000,Supervisors of Office and Administrative Support Workers,31030,Billing Supervisor,43.31030
+4263,43,1000,Supervisors of Office and Administrative Support Workers,31030,Billing Supervisor,43.3103
 4264,43,3000,Financial Clerks,10998,Billing Accountant,43.10998
 4265,43,9000,Other Office and Administrative Support Workers,30829,Operations Clerk,43.30829
 4266,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",30917,Master Scheduler,43.30917
 4267,43,3000,Financial Clerks,31198,Management Clerk,43.31198
 4268,43,4000,Information and Record Clerks,30286,Front Desk Clerk,43.30286
 4269,43,1000,Supervisors of Office and Administrative Support Workers,30136,Customer Service Manager,43.30136
-4270,43,4000,Information and Record Clerks,11240,Credit Coordinator,43.11240
+4270,43,4000,Information and Record Clerks,11240,Credit Coordinator,43.1124
 4271,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",10426,Central Scheduler,43.10426
 4272,43,1000,Supervisors of Office and Administrative Support Workers,31062,Audit Supervisor,43.31062
 4273,43,1000,Supervisors of Office and Administrative Support Workers,30368,Administrative Supervisor,43.30368
@@ -4292,7 +4292,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4290,43,4000,Information and Record Clerks,30845,Staff Officer (Office and Administrative Support),43.30845
 4291,43,4000,Information and Record Clerks,10331,Solutions Representative (Office and Administrative Support),43.10331
 4292,43,9000,Other Office and Administrative Support Workers,10128,Research Associate,43.10128
-4293,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31020,Production Warehouse (Office and Administrative Support),43.31020
+4293,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",31020,Production Warehouse (Office and Administrative Support),43.3102
 4294,43,1000,Supervisors of Office and Administrative Support Workers,31271,Planning Supervisor (Office and Administrative Support),43.31271
 4295,43,4000,Information and Record Clerks,31095,Mortgage Loan Coordinator (Office and Administrative Support),43.31095
 4296,43,9000,Other Office and Administrative Support Workers,11124,Medical Clerk (Office and Administrative Support),43.11124
@@ -4315,21 +4315,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4313,43,6000,Secretaries and Administrative Assistants,30993,Surgery Scheduler (Office and Administrative Support),43.30993
 4314,43,1000,Supervisors of Office and Administrative Support Workers,31505,Practice Supervisor (Office and Administrative Support),43.31505
 4315,43,9000,Other Office and Administrative Support Workers,31253,Planning Assistant (Office and Administrative Support),43.31253
-4316,43,1000,Supervisors of Office and Administrative Support Workers,31270,General Supervisor (Office and Administrative Support),43.31270
+4316,43,1000,Supervisors of Office and Administrative Support Workers,31270,General Supervisor (Office and Administrative Support),43.3127
 4317,43,4000,Information and Record Clerks,10141,Financial Representative (Office and Administrative Support),43.10141
 4318,43,9000,Other Office and Administrative Support Workers,30473,Data Coordinator (Office and Administrative Support),43.30473
-4319,43,1000,Supervisors of Office and Administrative Support Workers,30610,Control Supervisor (Office and Administrative Support),43.30610
-4320,43,3000,Financial Clerks,30140,Accounting Analyst (Office and Administrative Support),43.30140
+4319,43,1000,Supervisors of Office and Administrative Support Workers,30610,Control Supervisor (Office and Administrative Support),43.3061
+4320,43,3000,Financial Clerks,30140,Accounting Analyst (Office and Administrative Support),43.3014
 4321,43,4000,Information and Record Clerks,30162,Financial Services Representative (Office and Administrative Support),43.30162
 4322,43,1000,Supervisors of Office and Administrative Support Workers,31373,Assistant Supervisor (Office and Administrative Support),43.31373
-4323,43,9000,Other Office and Administrative Support Workers,1010,Proofreader (Office and Administrative Support),43.1010
+4323,43,9000,Other Office and Administrative Support Workers,1010,Proofreader (Office and Administrative Support),43.101
 4324,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",1059,Production Coordinator (Office and Administrative Support),43.1059
 4325,43,3000,Financial Clerks,1116,Biller,43.1116
 4326,43,1000,Supervisors of Office and Administrative Support Workers,1029,Accounts Administrator,43.1029
 4327,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",1166,Messenger,43.1166
 4328,43,4000,Information and Record Clerks,1113,Senior Clerk,43.1113
 4329,43,4000,Information and Record Clerks,1077,Judicial Clerk,43.1077
-4330,43,9000,Other Office and Administrative Support Workers,1180,Events Assistant,43.1180
+4330,43,9000,Other Office and Administrative Support Workers,1180,Events Assistant,43.118
 4331,43,4000,Information and Record Clerks,1167,Human Resources (HR) Manager (Office and Administrative Support),43.1167
 4332,43,3000,Financial Clerks,1097,Cashier (Office and Administrative Support),43.1097
 4333,43,4000,Information and Record Clerks,1198,Reservationist (Office and Administrative Support),43.1198
@@ -4344,12 +4344,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4342,43,9000,Other Office and Administrative Support Workers,1197,Notary Public (Office and Administrative Support),43.1197
 4343,43,9000,Other Office and Administrative Support Workers,1054,Program Assistant (Office and Administrative Support),43.1054
 4344,43,3000,Financial Clerks,1033,Account Specialist (Office and Administrative Support),43.1033
-4345,43,1000,Supervisors of Office and Administrative Support Workers,1060,Accounting Supervisor (Office and Administrative Support),43.1060
+4345,43,1000,Supervisors of Office and Administrative Support Workers,1060,Accounting Supervisor (Office and Administrative Support),43.106
 4346,43,3000,Financial Clerks,1123,Payroll Manager (Office and Administrative Support),43.1123
 4347,43,9000,Other Office and Administrative Support Workers,1083,Communication Assistant,43.1083
 4348,43,6000,Secretaries and Administrative Assistants,1119,Executive Support,43.1119
 4349,43,4000,Information and Record Clerks,1236,Senior Customer Service Representative,43.1236
-4350,43,1000,Supervisors of Office and Administrative Support Workers,1040,Head of Service,43.1040
+4350,43,1000,Supervisors of Office and Administrative Support Workers,1040,Head of Service,43.104
 4351,43,1000,Supervisors of Office and Administrative Support Workers,1132,Operations Administrator (Office and Administrative Support),43.1132
 4352,43,4000,Information and Record Clerks,1093,General Assistant,43.1093
 4353,43,9000,Other Office and Administrative Support Workers,1095,Signing Agent,43.1095
@@ -4364,7 +4364,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4362,43,5000,"Material Recording, Scheduling, Dispatching, and Distributing Workers",1112,Operations Coordinator (Office and Administrative Support),43.1112
 4363,43,3000,Financial Clerks,1143,Assistant Controller (Office and Administrative Support),43.1143
 4364,43,4000,Information and Record Clerks,2172,Complaints Officer,43.2172
-4365,45,2000,Agricultural Workers,0,"General Laborer (Farming, Fishing, and Forestry)",45.0
+4365,45,2000,Agricultural Workers,0,"General Laborer (Farming, Fishing, and Forestry)",45
 4366,45,2000,Agricultural Workers,1,Picker,45.1
 4367,45,2000,Agricultural Workers,2,Custom Applicator,45.2
 4368,45,2000,Agricultural Workers,4,Packer Inspector,45.4
@@ -4373,14 +4373,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4371,45,4000,"Forest, Conservation, and Logging Workers",7,Cable Puller,45.7
 4372,45,2000,Agricultural Workers,8,Livestock Handler,45.8
 4373,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",9,Farm Supervisor,45.9
-4374,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",10,Animal Facility Supervisor,45.10
+4374,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",10,Animal Facility Supervisor,45.1
 4375,45,2000,Agricultural Workers,11,Farm Equipment Operator,45.11
 4376,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",14,Farm Crew Leader,45.14
 4377,45,2000,Agricultural Workers,15,Meat and Poultry Inspector,45.15
 4378,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",16,Harvest Supervisor,45.16
 4379,45,3000,Fishing and Hunting Workers,18,Detasseler,45.18
 4380,45,2000,Agricultural Workers,19,Harvest Operator,45.19
-4381,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",20,Animal Care Supervisor,45.20
+4381,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",20,Animal Care Supervisor,45.2
 4382,45,2000,Agricultural Workers,21,Horse Stable Worker,45.21
 4383,45,2000,Agricultural Workers,22,Horse Groomer,45.22
 4384,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",24,Farm Manager,45.24
@@ -4391,7 +4391,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4389,45,2000,Agricultural Workers,34,Hardwood Lumber Grader,45.34
 4390,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",35,Logging Manager,45.35
 4391,45,2000,Agricultural Workers,39,Vineyard Equipment Operator,45.39
-4392,45,2000,Agricultural Workers,40,Agriculture Field Worker,45.40
+4392,45,2000,Agricultural Workers,40,Agriculture Field Worker,45.4
 4393,45,2000,Agricultural Workers,41,Dairy Plant Operator,45.41
 4394,45,2000,Agricultural Workers,42,"Nursery Worker (Farming, Fishing, and Forestry)",45.42
 4395,45,2000,Agricultural Workers,43,Produce Inspector,45.43
@@ -4400,16 +4400,16 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4398,45,2000,Agricultural Workers,49,Food Inspector,45.49
 4399,45,4000,"Forest, Conservation, and Logging Workers",58,"Tree Climber (Farming, Fishing, and Forestry)",45.58
 4400,45,2000,Agricultural Workers,59,Irrigator,45.59
-4401,45,4000,"Forest, Conservation, and Logging Workers",60,Log Scaler,45.60
+4401,45,4000,"Forest, Conservation, and Logging Workers",60,Log Scaler,45.6
 4402,45,2000,Agricultural Workers,61,Other Topics,45.61
 4403,45,2000,Agricultural Workers,11319,Farmer,45.11319
 4404,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",11087,Crop Consultant,45.11087
-4405,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",31270,"General Supervisor (Farming, Fishing, and Forestry)",45.31270
+4405,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",31270,"General Supervisor (Farming, Fishing, and Forestry)",45.3127
 4406,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",30425,"Care Supervisor (Farming, Fishing, and Forestry)",45.30425
 4407,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",30616,"Area Supervisor (Farming, Fishing, and Forestry)",45.30616
 4408,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1024,Horticultural Supervisor,45.1024
 4409,45,2000,Agricultural Workers,1022,"Field Operator (Farming, Fishing, and Forestry)",45.1022
-4410,45,2000,Agricultural Workers,1090,Cow Hand,45.1090
+4410,45,2000,Agricultural Workers,1090,Cow Hand,45.109
 4411,45,3000,Fishing and Hunting Workers,1027,Planter,45.1027
 4412,45,2000,Agricultural Workers,1016,Calf Raiser,45.1016
 4413,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1075,Animal Manager,45.1075
@@ -4423,8 +4423,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4421,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1064,Barn Assistant,45.1064
 4422,45,2000,Agricultural Workers,1091,Bull Rider,45.1091
 4423,45,2000,Agricultural Workers,1011,Stable Hand,45.1011
-4424,45,2000,Agricultural Workers,1100,Ranch Worker,45.1100
-4425,45,2000,Agricultural Workers,1020,"Sorter (Farming, Fishing, and Forestry)",45.1020
+4424,45,2000,Agricultural Workers,1100,Ranch Worker,45.11
+4425,45,2000,Agricultural Workers,1020,"Sorter (Farming, Fishing, and Forestry)",45.102
 4426,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1089,Ranch Supervisor,45.1089
 4427,45,3000,Fishing and Hunting Workers,1026,Trapper,45.1026
 4428,45,2000,Agricultural Workers,1046,Agriculture Officer,45.1046
@@ -4442,13 +4442,13 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4440,45,2000,Agricultural Workers,1051,Dairy Worker,45.1051
 4441,45,2000,Agricultural Workers,1017,Greenhouse Worker,45.1017
 4442,45,2000,Agricultural Workers,1067,Horticultural Specialist,45.1067
-4443,45,3000,Fishing and Hunting Workers,1180,"Captain (Farming, Fishing, and Forestry)",45.1180
+4443,45,3000,Fishing and Hunting Workers,1180,"Captain (Farming, Fishing, and Forestry)",45.118
 4444,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1117,Horticulture Coordinator,45.1117
 4445,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1116,Head of Agriculture,45.1116
 4446,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1059,Horticulture Assistant,45.1059
 4447,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1052,Nursery Director,45.1052
 4448,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1042,Forestry Supervisor,45.1042
-4449,45,2000,Agricultural Workers,1040,Farmhand,45.1040
+4449,45,2000,Agricultural Workers,1040,Farmhand,45.104
 4450,45,4000,"Forest, Conservation, and Logging Workers",1145,Nurseryman,45.1145
 4451,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1066,Dairy Manager,45.1066
 4452,45,2000,Agricultural Workers,1076,Agricultural Worker,45.1076
@@ -4465,11 +4465,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4463,45,2000,Agricultural Workers,1092,Barn Hand,45.1092
 4464,45,3000,Fishing and Hunting Workers,1045,Diver,45.1045
 4465,45,1000,"Supervisors of Farming, Fishing, and Forestry Workers",1082,Director of Horticulture,45.1082
-4466,45,2000,Agricultural Workers,1000,Farm Worker,45.1000
+4466,45,2000,Agricultural Workers,1000,Farm Worker,45.1
 4467,45,4000,"Forest, Conservation, and Logging Workers",1153,"Gardener (Farming, Fishing, and Forestry)",45.1153
 4468,45,2000,Agricultural Workers,1002,Bee Keeper,45.1002
 4469,45,2000,Agricultural Workers,1102,Fruit Picker,45.1102
-4470,47,2000,Construction Trades Workers,0,Sheet Metal Mechanic,47.0
+4470,47,2000,Construction Trades Workers,0,Sheet Metal Mechanic,47
 4471,47,2000,Construction Trades Workers,2,Equipment Operator (Construction and Extraction),47.2
 4472,47,2000,Construction Trades Workers,3,Industrial Electrician,47.3
 4473,47,2000,Construction Trades Workers,4,Journeyman Electrician,47.4
@@ -4477,7 +4477,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4475,47,2000,Construction Trades Workers,6,Pipe Fitter,47.6
 4476,47,2000,Construction Trades Workers,8,Construction Laborer,47.8
 4477,47,3000,"Helpers, Construction Trades",9,Electrician Apprentice,47.9
-4478,47,2000,Construction Trades Workers,10,Solar Photovoltaic (PV) Installer,47.10
+4478,47,2000,Construction Trades Workers,10,Solar Photovoltaic (PV) Installer,47.1
 4479,47,2000,Construction Trades Workers,11,Commercial Electrician,47.11
 4480,47,2000,Construction Trades Workers,12,Concrete Laborer,47.12
 4481,47,1000,Supervisors of Construction and Extraction Workers,13,Construction Supervisor,47.13
@@ -4487,7 +4487,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4485,47,1000,Supervisors of Construction and Extraction Workers,17,Construction Project Coordinator,47.17
 4486,47,2000,Construction Trades Workers,18,Sheet Metal Assembler,47.18
 4487,47,2000,Construction Trades Workers,19,Iron Worker,47.19
-4488,47,2000,Construction Trades Workers,20,Construction Inspector,47.20
+4488,47,2000,Construction Trades Workers,20,Construction Inspector,47.2
 4489,47,2000,Construction Trades Workers,21,Concrete Finisher,47.21
 4490,47,3000,"Helpers, Construction Trades",22,Electrician Helper,47.22
 4491,47,2000,Construction Trades Workers,23,Finish Carpenter,47.23
@@ -4496,7 +4496,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4494,47,2000,Construction Trades Workers,26,Master Plumber,47.26
 4495,47,2000,Construction Trades Workers,27,Construction Worker,47.27
 4496,47,2000,Construction Trades Workers,29,Sheet Metal Worker,47.29
-4497,47,4000,Other Construction and Related Workers,30,Track Maintenance Laborer,47.30
+4497,47,4000,Other Construction and Related Workers,30,Track Maintenance Laborer,47.3
 4498,47,2000,Construction Trades Workers,31,Bathroom Installer,47.31
 4499,47,2000,Construction Trades Workers,32,Construction Administrator,47.32
 4500,47,2000,Construction Trades Workers,33,Concrete Inspector,47.33
@@ -4506,7 +4506,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4504,47,2000,Construction Trades Workers,37,Form Carpenter,47.37
 4505,47,3000,"Helpers, Construction Trades",38,Electrical Apprentice,47.38
 4506,47,2000,Construction Trades Workers,39,Sheet Metal Fabricator,47.39
-4507,47,3000,"Helpers, Construction Trades",40,Construction Helper,47.40
+4507,47,3000,"Helpers, Construction Trades",40,Construction Helper,47.4
 4508,47,2000,Construction Trades Workers,41,Marine Electrician,47.41
 4509,47,2000,Construction Trades Workers,42,Field Operator (Construction and Extraction),47.42
 4510,47,2000,Construction Trades Workers,43,Construction Coordinator,47.43
@@ -4514,7 +4514,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4512,47,2000,Construction Trades Workers,46,Commercial Carpenter,47.46
 4513,47,3000,"Helpers, Construction Trades",48,Electrical Helper,47.48
 4514,47,2000,Construction Trades Workers,49,Service Electrician,47.49
-4515,47,1000,Supervisors of Construction and Extraction Workers,50,Field Supervisor (Construction and Extraction),47.50
+4515,47,1000,Supervisors of Construction and Extraction Workers,50,Field Supervisor (Construction and Extraction),47.5
 4516,47,2000,Construction Trades Workers,52,Plant Electrician,47.52
 4517,47,1000,Supervisors of Construction and Extraction Workers,54,Electrical Superintendent,47.54
 4518,47,2000,Construction Trades Workers,55,Master Electrician,47.55
@@ -4522,7 +4522,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4520,47,2000,Construction Trades Workers,57,Residential Electrician,47.57
 4521,47,3000,"Helpers, Construction Trades",58,Carpenter Helper,47.58
 4522,47,2000,Construction Trades Workers,59,Lead Carpenter,47.59
-4523,47,1000,Supervisors of Construction and Extraction Workers,60,Crew Leader,47.60
+4523,47,1000,Supervisors of Construction and Extraction Workers,60,Crew Leader,47.6
 4524,47,2000,Construction Trades Workers,63,Tile Installer,47.63
 4525,47,3000,"Helpers, Construction Trades",64,Electrician Technician,47.64
 4526,47,1000,Supervisors of Construction and Extraction Workers,65,Drywall Construction Estimator,47.65
@@ -4530,18 +4530,18 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4528,47,5000,Extraction Workers,67,Wireline Operator,47.67
 4529,47,2000,Construction Trades Workers,68,Construction Scheduler,47.68
 4530,47,1000,Supervisors of Construction and Extraction Workers,69,Assistant Construction Superintendent,47.69
-4531,47,4000,Other Construction and Related Workers,70,Transportation Worker,47.70
+4531,47,4000,Other Construction and Related Workers,70,Transportation Worker,47.7
 4532,47,5000,Extraction Workers,71,Ordnance Recovery Technician,47.71
 4533,47,2000,Construction Trades Workers,73,Window Installer,47.73
 4534,47,2000,Construction Trades Workers,75,Solar Electrician,47.75
 4535,47,4000,Other Construction and Related Workers,76,Building Inspector,47.76
 4536,47,2000,Construction Trades Workers,77,Rough Carpenter,47.77
-4537,47,1000,Supervisors of Construction and Extraction Workers,80,Installation Manager (Construction and Extraction),47.80
+4537,47,1000,Supervisors of Construction and Extraction Workers,80,Installation Manager (Construction and Extraction),47.8
 4538,47,2000,Construction Trades Workers,81,Project Administrator (Construction and Extraction),47.81
 4539,47,2000,Construction Trades Workers,85,Plumbing Technician,47.85
 4540,47,2000,Construction Trades Workers,86,Panel Builder,47.86
 4541,47,2000,Construction Trades Workers,89,Boilermaker,47.89
-4542,47,2000,Construction Trades Workers,90,Fire Sprinkler Fitter,47.90
+4542,47,2000,Construction Trades Workers,90,Fire Sprinkler Fitter,47.9
 4543,47,1000,Supervisors of Construction and Extraction Workers,92,Concrete Foreman,47.92
 4544,47,2000,Construction Trades Workers,93,Mason,47.93
 4545,47,2000,Construction Trades Workers,94,Operating Engineer (Construction and Extraction),47.94
@@ -4556,7 +4556,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4554,47,4000,Other Construction and Related Workers,107,Construction Engineer and Inspection (CEI) Inspector,47.107
 4555,47,2000,Construction Trades Workers,108,Substation Electrician,47.108
 4556,47,2000,Construction Trades Workers,109,Instrument Fitter,47.109
-4557,47,2000,Construction Trades Workers,110,Facilities Electrician,47.110
+4557,47,2000,Construction Trades Workers,110,Facilities Electrician,47.11
 4558,47,2000,Construction Trades Workers,112,Signal Apprentice,47.112
 4559,47,2000,Construction Trades Workers,113,Concrete Superintendent,47.113
 4560,47,2000,Construction Trades Workers,114,Pipe Laborer,47.114
@@ -4570,7 +4570,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4568,47,2000,Construction Trades Workers,126,Mine Electrician,47.126
 4569,47,2000,Construction Trades Workers,128,Electrical Journeyman,47.128
 4570,47,2000,Construction Trades Workers,129,Jack Operator,47.129
-4571,47,2000,Construction Trades Workers,130,Water Proofer,47.130
+4571,47,2000,Construction Trades Workers,130,Water Proofer,47.13
 4572,47,5000,Extraction Workers,132,Roustabout,47.132
 4573,47,2000,Construction Trades Workers,134,Sheet Metal Journeyman,47.134
 4574,47,2000,Construction Trades Workers,137,"Heating, Ventilation, and Air Conditioning (HVAC) Sheet Metal Installer",47.137
@@ -4594,7 +4594,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4592,47,4000,Other Construction and Related Workers,167,Assistant Elevator Manager,47.167
 4593,47,1000,Supervisors of Construction and Extraction Workers,168,Carpenter Foreman,47.168
 4594,47,1000,Supervisors of Construction and Extraction Workers,169,Solar Foreman,47.169
-4595,47,2000,Construction Trades Workers,170,Carpenter Assembler,47.170
+4595,47,2000,Construction Trades Workers,170,Carpenter Assembler,47.17
 4596,47,2000,Construction Trades Workers,172,Lead Installer,47.172
 4597,47,2000,Construction Trades Workers,173,Siding Installer,47.173
 4598,47,2000,Construction Trades Workers,174,Wireman,47.174
@@ -4610,20 +4610,20 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4608,47,2000,Construction Trades Workers,187,Pipe Insulator,47.187
 4609,47,2000,Construction Trades Workers,188,Construction Framer,47.188
 4610,47,1000,Supervisors of Construction and Extraction Workers,189,Piping Superintendent,47.189
-4611,47,2000,Construction Trades Workers,190,Well Test Operator,47.190
+4611,47,2000,Construction Trades Workers,190,Well Test Operator,47.19
 4612,47,5000,Extraction Workers,192,Blaster,47.192
 4613,47,1000,Supervisors of Construction and Extraction Workers,193,Project Supervisor,47.193
 4614,47,2000,Construction Trades Workers,194,Maintenance Carpenter,47.194
 4615,47,2000,Construction Trades Workers,195,Construction Lead,47.195
 4616,47,3000,"Helpers, Construction Trades",197,Roofing Laborer,47.197
 4617,47,1000,Supervisors of Construction and Extraction Workers,199,Pipe Foreman,47.199
-4618,47,2000,Construction Trades Workers,200,Wetcast Laborer,47.200
+4618,47,2000,Construction Trades Workers,200,Wetcast Laborer,47.2
 4619,47,2000,Construction Trades Workers,201,Tradesman,47.201
 4620,47,2000,Construction Trades Workers,203,Sheet Metal Operator,47.203
 4621,47,2000,Construction Trades Workers,207,Field Electrician,47.207
 4622,47,3000,"Helpers, Construction Trades",208,General Helper,47.208
-4623,47,2000,Construction Trades Workers,210,Other Topics,47.210
-4624,47,2000,Construction Trades Workers,10470,Framer,47.10470
+4623,47,2000,Construction Trades Workers,210,Other Topics,47.21
+4624,47,2000,Construction Trades Workers,10470,Framer,47.1047
 4625,47,4000,Other Construction and Related Workers,30808,Track Laborer,47.30808
 4626,47,1000,Supervisors of Construction and Extraction Workers,30398,House Supervisor,47.30398
 4627,47,2000,Construction Trades Workers,11254,Gutter,47.11254
@@ -4631,21 +4631,21 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4629,47,2000,Construction Trades Workers,11202,Drywall Hanger,47.11202
 4630,47,1000,Supervisors of Construction and Extraction Workers,30128,Superintendent (Construction and Extraction),47.30128
 4631,47,4000,Other Construction and Related Workers,30985,Safety Inspector (Construction and Extraction),47.30985
-4632,47,2000,Construction Trades Workers,30570,Piping Designer (Construction and Extraction),47.30570
+4632,47,2000,Construction Trades Workers,30570,Piping Designer (Construction and Extraction),47.3057
 4633,47,1000,Supervisors of Construction and Extraction Workers,30837,Independent Contractor (Construction and Extraction),47.30837
-4634,47,1000,Supervisors of Construction and Extraction Workers,31270,General Supervisor (Construction and Extraction),47.31270
+4634,47,1000,Supervisors of Construction and Extraction Workers,31270,General Supervisor (Construction and Extraction),47.3127
 4635,47,1000,Supervisors of Construction and Extraction Workers,30959,Floor Supervisor (Construction and Extraction),47.30959
 4636,47,4000,Other Construction and Related Workers,31009,Construction Technician (Construction and Extraction),47.31009
 4637,47,2000,Construction Trades Workers,10833,Drywall Finisher,47.10833
 4638,47,1000,Supervisors of Construction and Extraction Workers,30276,Foreman (Construction and Extraction),47.30276
 4639,47,1000,Supervisors of Construction and Extraction Workers,31476,Electrical Supervisor (Construction and Extraction),47.31476
-4640,47,2000,Construction Trades Workers,1040,Bricklayer,47.1040
+4640,47,2000,Construction Trades Workers,1040,Bricklayer,47.104
 4641,47,2000,Construction Trades Workers,1067,Head of Construction,47.1067
 4642,47,1000,Supervisors of Construction and Extraction Workers,1038,Installations Manager,47.1038
 4643,47,4000,Other Construction and Related Workers,1083,Paver,47.1083
 4644,47,5000,Extraction Workers,1025,Miner,47.1025
 4645,47,1000,Supervisors of Construction and Extraction Workers,1021,Operations Supervisor (Construction and Extraction),47.1021
-4646,47,2000,Construction Trades Workers,1120,Gaffer,47.1120
+4646,47,2000,Construction Trades Workers,1120,Gaffer,47.112
 4647,47,2000,Construction Trades Workers,1006,Steamfitter,47.1006
 4648,47,1000,Supervisors of Construction and Extraction Workers,1041,Operations Manager (Construction and Extraction),47.1041
 4649,47,4000,Other Construction and Related Workers,1057,Chief Inspector,47.1057
@@ -4654,7 +4654,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4652,47,1000,Supervisors of Construction and Extraction Workers,1052,Gang Boss,47.1052
 4653,47,1000,Supervisors of Construction and Extraction Workers,1088,Contract Supervisor,47.1088
 4654,47,2000,Construction Trades Workers,1022,Construction Manager (Construction and Extraction),47.1022
-4655,47,1000,Supervisors of Construction and Extraction Workers,1080,Assistant Superintendent,47.1080
+4655,47,1000,Supervisors of Construction and Extraction Workers,1080,Assistant Superintendent,47.108
 4656,47,5000,Extraction Workers,1099,Handyman (Construction and Extraction),47.1099
 4657,47,2000,Construction Trades Workers,1024,Paperhanger,47.1024
 4658,47,2000,Construction Trades Workers,1136,Chargehand,47.1136
@@ -4677,7 +4677,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4675,47,2000,Construction Trades Workers,1046,Welder (Construction and Extraction),47.1046
 4676,47,2000,Construction Trades Workers,1026,Estimator (Construction and Extraction),47.1026
 4677,47,2000,Construction Trades Workers,1105,Lather,47.1105
-4678,49,9000,"Other Installation, Maintenance, and Repair Occupations",0,Maintenance Mechanic,49.0
+4678,49,9000,"Other Installation, Maintenance, and Repair Occupations",0,Maintenance Mechanic,49
 4679,49,9000,"Other Installation, Maintenance, and Repair Occupations",1,Appliance Repair Technician,49.1
 4680,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",2,"Maintenance Manager (Installation, Maintenance, and Repair)",49.2
 4681,49,9000,"Other Installation, Maintenance, and Repair Occupations",3,"Maintenance Technician (Installation, Maintenance, and Repair)",49.3
@@ -4687,7 +4687,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4685,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",7,"Avionics Technician (Installation, Maintenance, and Repair)",49.7
 4686,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",8,Satellite TV Technician,49.8
 4687,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",9,Helicopter Mechanic,49.9
-4688,49,9000,"Other Installation, Maintenance, and Repair Occupations",10,HVAC Service Technician,49.10
+4688,49,9000,"Other Installation, Maintenance, and Repair Occupations",10,HVAC Service Technician,49.1
 4689,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",11,Maintenance Coordinator,49.11
 4690,49,9000,"Other Installation, Maintenance, and Repair Occupations",12,Maintenance Worker,49.12
 4691,49,9000,"Other Installation, Maintenance, and Repair Occupations",13,Maintenance Assistant,49.13
@@ -4697,7 +4697,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4695,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",17,Equipment Mechanic,49.17
 4696,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",18,Engine Repair Technician,49.18
 4697,49,9000,"Other Installation, Maintenance, and Repair Occupations",19,"Cable Technician (Installation, Maintenance, and Repair)",49.19
-4698,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",20,Aircraft Mechanic,49.20
+4698,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",20,Aircraft Mechanic,49.2
 4699,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",21,Equipment Technician,49.21
 4700,49,9000,"Other Installation, Maintenance, and Repair Occupations",22,Facility Maintenance Technician,49.22
 4701,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",23,Auto Body Technician,49.23
@@ -4707,14 +4707,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4705,49,9000,"Other Installation, Maintenance, and Repair Occupations",27,Maintenance Millwright,49.27
 4706,49,9000,"Other Installation, Maintenance, and Repair Occupations",28,Building Maintenance Worker,49.28
 4707,49,9000,"Other Installation, Maintenance, and Repair Occupations",29,Premises Technician,49.29
-4708,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",30,Automotive Technician,49.30
+4708,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",30,Automotive Technician,49.3
 4709,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",33,Electronic Technician,49.33
 4710,49,9000,"Other Installation, Maintenance, and Repair Occupations",34,PLC Maintenance Technician,49.34
 4711,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",35,Telecommunications Technician,49.35
 4712,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",36,Tire Technician,49.36
 4713,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",37,Airframe Powerplant Technician,49.37
 4714,49,9000,"Other Installation, Maintenance, and Repair Occupations",38,Apartment Maintenance Technician,49.38
-4715,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",40,Transmission Technician,49.40
+4715,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",40,Transmission Technician,49.4
 4716,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",41,Tower Climber,49.41
 4717,49,9000,"Other Installation, Maintenance, and Repair Occupations",42,HVAC Journeyman,49.42
 4718,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",43,Field Service Engineer,49.43
@@ -4724,7 +4724,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4722,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",47,Wireless Technician,49.47
 4723,49,9000,"Other Installation, Maintenance, and Repair Occupations",48,"Systems Technician (Installation, Maintenance, and Repair)",49.48
 4724,49,9000,"Other Installation, Maintenance, and Repair Occupations",49,Structures Technician,49.49
-4725,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",50,Body Shop Estimator,49.50
+4725,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",50,Body Shop Estimator,49.5
 4726,49,9000,"Other Installation, Maintenance, and Repair Occupations",51,Garage Door Installer,49.51
 4727,49,9000,"Other Installation, Maintenance, and Repair Occupations",52,Maintenance Representative,49.52
 4728,49,9000,"Other Installation, Maintenance, and Repair Occupations",53,Television Repair Technician,49.53
@@ -4733,7 +4733,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4731,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",56,Security Systems Installer,49.56
 4732,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",57,Crane Technician,49.57
 4733,49,9000,"Other Installation, Maintenance, and Repair Occupations",59,Journeyman Lineman,49.59
-4734,49,9000,"Other Installation, Maintenance, and Repair Occupations",60,HVAC Controls Technician,49.60
+4734,49,9000,"Other Installation, Maintenance, and Repair Occupations",60,HVAC Controls Technician,49.6
 4735,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",61,Aircraft Technician,49.61
 4736,49,9000,"Other Installation, Maintenance, and Repair Occupations",62,"Operations Technician (Installation, Maintenance, and Repair)",49.62
 4737,49,9000,"Other Installation, Maintenance, and Repair Occupations",63,"Instrumentation Technician (Installation, Maintenance, and Repair)",49.63
@@ -4741,7 +4741,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4739,49,9000,"Other Installation, Maintenance, and Repair Occupations",65,Preventative Maintenance Technician,49.65
 4740,49,9000,"Other Installation, Maintenance, and Repair Occupations",67,Utilities Technician,49.67
 4741,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",68,Auto Body Painter,49.68
-4742,49,9000,"Other Installation, Maintenance, and Repair Occupations",70,Shop Helper,49.70
+4742,49,9000,"Other Installation, Maintenance, and Repair Occupations",70,Shop Helper,49.7
 4743,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",71,Cell Technician,49.71
 4744,49,9000,"Other Installation, Maintenance, and Repair Occupations",72,Valve Technician,49.72
 4745,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",73,Copier Technician,49.73
@@ -4755,14 +4755,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4753,49,9000,"Other Installation, Maintenance, and Repair Occupations",87,Broadband Technician,49.87
 4754,49,9000,"Other Installation, Maintenance, and Repair Occupations",88,Tool Repairman,49.88
 4755,49,9000,"Other Installation, Maintenance, and Repair Occupations",89,Multi-craft Maintenance Technician,49.89
-4756,49,9000,"Other Installation, Maintenance, and Repair Occupations",90,Railcar Repairer,49.90
+4756,49,9000,"Other Installation, Maintenance, and Repair Occupations",90,Railcar Repairer,49.9
 4757,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",91,"Assembly Technician (Installation, Maintenance, and Repair)",49.91
 4758,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",93,PBX Technician,49.93
 4759,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",95,Central Office Technician,49.95
 4760,49,9000,"Other Installation, Maintenance, and Repair Occupations",96,Manufacturing Maintenance Technician,49.96
 4761,49,9000,"Other Installation, Maintenance, and Repair Occupations",97,Maintenance Handyman,49.97
 4762,49,9000,"Other Installation, Maintenance, and Repair Occupations",98,"Welder (Installation, Maintenance, and Repair)",49.98
-4763,49,9000,"Other Installation, Maintenance, and Repair Occupations",100,HVAC Refrigeration Technician,49.100
+4763,49,9000,"Other Installation, Maintenance, and Repair Occupations",100,HVAC Refrigeration Technician,49.1
 4764,49,9000,"Other Installation, Maintenance, and Repair Occupations",101,Lawn Garden Repair Technician,49.101
 4765,49,9000,"Other Installation, Maintenance, and Repair Occupations",102,Property Maintenance Technician,49.102
 4766,49,9000,"Other Installation, Maintenance, and Repair Occupations",103,Assembly Mechanic,49.103
@@ -4772,27 +4772,27 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4770,49,9000,"Other Installation, Maintenance, and Repair Occupations",107,Maintenance Foreman,49.107
 4771,49,9000,"Other Installation, Maintenance, and Repair Occupations",108,Hydraulics Maintenance Technician,49.108
 4772,49,9000,"Other Installation, Maintenance, and Repair Occupations",109,Locksmith,49.109
-4773,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",110,Facilities Specialist,49.110
+4773,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",110,Facilities Specialist,49.11
 4774,49,9000,"Other Installation, Maintenance, and Repair Occupations",113,Installation Test Technician,49.113
 4775,49,9000,"Other Installation, Maintenance, and Repair Occupations",117,"Installation, Maintenance, and Repair Worker",49.117
 4776,49,9000,"Other Installation, Maintenance, and Repair Occupations",118,Splicer,49.118
 4777,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",119,Trailer Technician,49.119
-4778,49,9000,"Other Installation, Maintenance, and Repair Occupations",120,Refrigeration Technician,49.120
+4778,49,9000,"Other Installation, Maintenance, and Repair Occupations",120,Refrigeration Technician,49.12
 4779,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",121,Aircraft Painting Supervisor,49.121
 4780,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",122,CCTV Technician,49.122
 4781,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",123,"Automation Technician (Installation, Maintenance, and Repair)",49.123
 4782,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",124,Service Technician,49.124
 4783,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",126,Power Technician,49.126
 4784,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",129,Compressor Mechanic,49.129
-4785,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",130,Oil Technician,49.130
+4785,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",130,Oil Technician,49.13
 4786,49,9000,"Other Installation, Maintenance, and Repair Occupations",131,Plant Operations Technician,49.131
 4787,49,9000,"Other Installation, Maintenance, and Repair Occupations",733,Other Topics,49.733
-4788,49,9000,"Other Installation, Maintenance, and Repair Occupations",30320,"Heating, Ventilation, and Air Conditioning (HVAC) Mechanic",49.30320
-4789,49,9000,"Other Installation, Maintenance, and Repair Occupations",30470,"Handyman (Installation, Maintenance, and Repair)",49.30470
-4790,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",10710,Automotive Service Excellence (ASE) Technician,49.10710
+4788,49,9000,"Other Installation, Maintenance, and Repair Occupations",30320,"Heating, Ventilation, and Air Conditioning (HVAC) Mechanic",49.3032
+4789,49,9000,"Other Installation, Maintenance, and Repair Occupations",30470,"Handyman (Installation, Maintenance, and Repair)",49.3047
+4790,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",10710,Automotive Service Excellence (ASE) Technician,49.1071
 4791,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",31211,Vehicle Technician,49.31211
 4792,49,9000,"Other Installation, Maintenance, and Repair Occupations",10301,Utilities Worker,49.10301
-4793,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",30640,Shop Technician,49.30640
+4793,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",30640,Shop Technician,49.3064
 4794,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",31508,Security Technician,49.31508
 4795,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",10907,Mobile Technician,49.10907
 4796,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30592,Maintenance Planner,49.30592
@@ -4808,7 +4808,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4806,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",31366,Mechanic Supervisor,49.31366
 4807,49,9000,"Other Installation, Maintenance, and Repair Occupations",10405,Maintenance Leader,49.10405
 4808,49,9000,"Other Installation, Maintenance, and Repair Occupations",11313,Maintenance Analyst,49.11313
-4809,49,9000,"Other Installation, Maintenance, and Repair Occupations",31170,Installation Helper,49.31170
+4809,49,9000,"Other Installation, Maintenance, and Repair Occupations",31170,Installation Helper,49.3117
 4810,49,9000,"Other Installation, Maintenance, and Repair Occupations",31139,General Service Technician,49.31139
 4811,49,9000,"Other Installation, Maintenance, and Repair Occupations",30667,Central Service Technician,49.30667
 4812,49,9000,"Other Installation, Maintenance, and Repair Occupations",30496,Automotive Service Advisor,49.30496
@@ -4820,7 +4820,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4818,49,9000,"Other Installation, Maintenance, and Repair Occupations",31313,Commercial Service Technician,49.31313
 4819,49,9000,"Other Installation, Maintenance, and Repair Occupations",30831,Equipment Repairer,49.30831
 4820,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30735,"Technical Supervisor (Installation, Maintenance, and Repair)",49.30735
-4821,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",10390,"Shop Manager (Installation, Maintenance, and Repair)",49.10390
+4821,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",10390,"Shop Manager (Installation, Maintenance, and Repair)",49.1039
 4822,49,9000,"Other Installation, Maintenance, and Repair Occupations",30837,"Independent Contractor (Installation, Maintenance, and Repair)",49.30837
 4823,49,9000,"Other Installation, Maintenance, and Repair Occupations",31234,"Hospital Service Technician (Installation, Maintenance, and Repair)",49.31234
 4824,49,9000,"Other Installation, Maintenance, and Repair Occupations",30276,"Foreman (Installation, Maintenance, and Repair)",49.30276
@@ -4831,8 +4831,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4829,49,9000,"Other Installation, Maintenance, and Repair Occupations",30587,Biomedical Equipment Technician,49.30587
 4830,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30818,"Systems Supervisor (Installation, Maintenance, and Repair)",49.30818
 4831,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",11058,"Shop Assistant (Installation, Maintenance, and Repair)",49.11058
-4832,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",31270,"General Supervisor (Installation, Maintenance, and Repair)",49.31270
-4833,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30610,"Control Supervisor (Installation, Maintenance, and Repair)",49.30610
+4832,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",31270,"General Supervisor (Installation, Maintenance, and Repair)",49.3127
+4833,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30610,"Control Supervisor (Installation, Maintenance, and Repair)",49.3061
 4834,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",31476,"Electrical Supervisor (Installation, Maintenance, and Repair)",49.31476
 4835,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",30616,"Area Supervisor (Installation, Maintenance, and Repair)",49.30616
 4836,49,9000,"Other Installation, Maintenance, and Repair Occupations",1059,Head of Maintenance,49.1059
@@ -4844,12 +4844,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4842,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1049,Engine Mechanic,49.1049
 4843,49,2000,"Electrical and Electronic Equipment Mechanics, Installers, and Repairers",1145,Troubleshooter,49.1145
 4844,49,9000,"Other Installation, Maintenance, and Repair Occupations",1086,"Operations Manager (Installation, Maintenance, and Repair)",49.1086
-4845,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1160,Bodyman,49.1160
+4845,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1160,Bodyman,49.116
 4846,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1056,"Crew Chief (Installation, Maintenance, and Repair)",49.1056
 4847,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1061,Master Technician,49.1061
 4848,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1087,Equipment Specialist,49.1087
 4849,49,9000,"Other Installation, Maintenance, and Repair Occupations",1027,"Maintenance Officer (Installation, Maintenance, and Repair)",49.1027
-4850,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1080,Bike Mechanic,49.1080
+4850,49,3000,"Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",1080,Bike Mechanic,49.108
 4851,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1093,Equipment Supervisor,49.1093
 4852,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1119,"Fleet Manager (Installation, Maintenance, and Repair)",49.1119
 4853,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1104,Installation Supervisor,49.1104
@@ -4873,7 +4873,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4871,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1157,"Field Supervisor (Installation, Maintenance, and Repair)",49.1157
 4872,49,9000,"Other Installation, Maintenance, and Repair Occupations",1017,"Mechanical Technician (Installation, Maintenance, and Repair)",49.1017
 4873,49,1000,"Supervisors of Installation, Maintenance, and Repair Workers",1009,"Maintenance Supervisor (Installation, Maintenance, and Repair)",49.1009
-4874,51,4000,Metal Workers and Plastic Workers,0,CNC Machinist,51.0
+4874,51,4000,Metal Workers and Plastic Workers,0,CNC Machinist,51
 4875,51,4000,Metal Workers and Plastic Workers,1,Machine Operator (Production),51.1
 4876,51,9000,Other Production Occupations,2,Production Worker,51.2
 4877,51,2000,Assemblers and Fabricators,3,Production Supervisor,51.3
@@ -4883,7 +4883,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4881,51,4000,Metal Workers and Plastic Workers,7,CNC Programmer,51.7
 4882,51,9000,Other Production Occupations,8,Press Operator,51.8
 4883,51,9000,Other Production Occupations,9,CNC Operator,51.9
-4884,51,1000,Supervisors of Production Workers,10,Assembly Supervisor,51.10
+4884,51,1000,Supervisors of Production Workers,10,Assembly Supervisor,51.1
 4885,51,1000,Supervisors of Production Workers,11,Production Manager (Production),51.11
 4886,51,2000,Assemblers and Fabricators,13,Electronic Assembler,51.13
 4887,51,9000,Other Production Occupations,14,Quality Control Inspector,51.14
@@ -4899,7 +4899,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4897,51,2000,Assemblers and Fabricators,27,Assembly Technician (Production),51.27
 4898,51,9000,Other Production Occupations,28,Mechanical Inspector,51.28
 4899,51,9000,Other Production Occupations,29,Production Leader,51.29
-4900,51,1000,Supervisors of Production Workers,30,Department Supervisor,51.30
+4900,51,1000,Supervisors of Production Workers,30,Department Supervisor,51.3
 4901,51,1000,Supervisors of Production Workers,31,Manufacturing Manager (Production),51.31
 4902,51,2000,Assemblers and Fabricators,32,Assembly Worker,51.32
 4903,51,1000,Supervisors of Production Workers,33,Process Supervisor,51.33
@@ -4916,7 +4916,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4914,51,2000,Assemblers and Fabricators,47,Manufacturing Assembler,51.47
 4915,51,9000,Other Production Occupations,48,SMT Operator,51.48
 4916,51,4000,Metal Workers and Plastic Workers,49,Mold Maker,51.49
-4917,51,5000,Printing Workers,50,Production Coordinator (Production),51.50
+4917,51,5000,Printing Workers,50,Production Coordinator (Production),51.5
 4918,51,2000,Assemblers and Fabricators,51,Wire Assembler,51.51
 4919,51,9000,Other Production Occupations,52,Packaging Operator,51.52
 4920,51,4000,Metal Workers and Plastic Workers,53,Electronical Solderer,51.53
@@ -4924,7 +4924,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4922,51,8000,Plant and System Operators,56,Wastewater Operator,51.56
 4923,51,4000,Metal Workers and Plastic Workers,57,Fabricator,51.57
 4924,51,2000,Assemblers and Fabricators,58,Line Leader,51.58
-4925,51,4000,Metal Workers and Plastic Workers,60,Structural Fitter,51.60
+4925,51,4000,Metal Workers and Plastic Workers,60,Structural Fitter,51.6
 4926,51,1000,Supervisors of Production Workers,61,Shop Supervisor,51.61
 4927,51,2000,Assemblers and Fabricators,62,Machine Builder,51.62
 4928,51,1000,Supervisors of Production Workers,63,Quality Supervisor,51.63
@@ -4933,7 +4933,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4931,51,7000,Woodworkers,66,Saw Operator,51.66
 4932,51,5000,Printing Workers,67,Stitcher Operator,51.67
 4933,51,7000,Woodworkers,68,Cabinet Maker,51.68
-4934,51,6000,"Textile, Apparel, and Furnishings Workers",70,Extrusion Operator,51.70
+4934,51,6000,"Textile, Apparel, and Furnishings Workers",70,Extrusion Operator,51.7
 4935,51,3000,Food Processing Workers,71,Cake Decorator,51.71
 4936,51,9000,Other Production Occupations,72,Materials Tester,51.72
 4937,51,9000,Other Production Occupations,73,Manufacturing Technician (Production),51.73
@@ -4942,7 +4942,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4940,51,8000,Plant and System Operators,77,Process Operator,51.77
 4941,51,9000,Other Production Occupations,78,Grinder,51.78
 4942,51,9000,Other Production Occupations,79,Soldering Technician,51.79
-4943,51,9000,Other Production Occupations,80,Production Helper,51.80
+4943,51,9000,Other Production Occupations,80,Production Helper,51.8
 4944,51,1000,Supervisors of Production Workers,81,Sanitation Supervisor,51.81
 4945,51,9000,Other Production Occupations,82,CMM Inspector,51.82
 4946,51,2000,Assemblers and Fabricators,84,Solder Assembler,51.84
@@ -4950,7 +4950,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4948,51,2000,Assemblers and Fabricators,87,Production Staff,51.87
 4949,51,9000,Other Production Occupations,88,Line Operator,51.88
 4950,51,8000,Plant and System Operators,89,Equipment Operator (Production),51.89
-4951,51,1000,Supervisors of Production Workers,90,Manufacturing Team Lead,51.90
+4951,51,1000,Supervisors of Production Workers,90,Manufacturing Team Lead,51.9
 4952,51,4000,Metal Workers and Plastic Workers,92,Maintenance Machinist (Production),51.92
 4953,51,2000,Assemblers and Fabricators,93,Small Parts Assembler,51.93
 4954,51,6000,"Textile, Apparel, and Furnishings Workers",94,Laser Operator,51.94
@@ -4959,7 +4959,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4957,51,9000,Other Production Occupations,97,Painter (Production),51.97
 4958,51,8000,Plant and System Operators,98,Stationary Engineer,51.98
 4959,51,1000,Supervisors of Production Workers,99,Line Supervisor,51.99
-4960,51,2000,Assemblers and Fabricators,100,Ship Fitter,51.100
+4960,51,2000,Assemblers and Fabricators,100,Ship Fitter,51.1
 4961,51,9000,Other Production Occupations,101,Electronic Inspector,51.101
 4962,51,9000,Other Production Occupations,102,Quality Coordinator,51.102
 4963,51,1000,Supervisors of Production Workers,103,Shop Foreman,51.103
@@ -4968,7 +4968,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4966,51,2000,Assemblers and Fabricators,107,Cable Assembler,51.107
 4967,51,2000,Assemblers and Fabricators,108,Production Specialist,51.108
 4968,51,4000,Metal Workers and Plastic Workers,109,Tool and Die Machinist,51.109
-4969,51,2000,Assemblers and Fabricators,110,Aerospace Assembler,51.110
+4969,51,2000,Assemblers and Fabricators,110,Aerospace Assembler,51.11
 4970,51,9000,Other Production Occupations,111,Certified Welding Inspector,51.111
 4971,51,4000,Metal Workers and Plastic Workers,112,Mastercam Programmer,51.112
 4972,51,9000,Other Production Occupations,113,Assembly Lead,51.113
@@ -4977,7 +4977,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4975,51,2000,Assemblers and Fabricators,116,Light Assembler,51.116
 4976,51,4000,Metal Workers and Plastic Workers,117,Machinist Mate,51.117
 4977,51,9000,Other Production Occupations,119,Blending Operator,51.119
-4978,51,1000,Supervisors of Production Workers,120,FSQA Supervisor,51.120
+4978,51,1000,Supervisors of Production Workers,120,FSQA Supervisor,51.12
 4979,51,2000,Assemblers and Fabricators,121,Automotive Assembler,51.121
 4980,51,1000,Supervisors of Production Workers,122,Welding Supervisor,51.122
 4981,51,9000,Other Production Occupations,123,Lab Technician,51.123
@@ -4986,7 +4986,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4984,51,1000,Supervisors of Production Workers,126,Operations Coordinator (Production),51.126
 4985,51,4000,Metal Workers and Plastic Workers,128,Conventional Machinist,51.128
 4986,51,2000,Assemblers and Fabricators,129,Aircraft Assembler,51.129
-4987,51,1000,Supervisors of Production Workers,130,Materials Supervisor (Production),51.130
+4987,51,1000,Supervisors of Production Workers,130,Materials Supervisor (Production),51.13
 4988,51,9000,Other Production Occupations,131,Glass Worker,51.131
 4989,51,4000,Metal Workers and Plastic Workers,133,Manufacturing Lead,51.133
 4990,51,4000,Metal Workers and Plastic Workers,134,Slitter Operator,51.134
@@ -4994,7 +4994,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 4992,51,9000,Other Production Occupations,136,Assembler Tester,51.136
 4993,51,2000,Assemblers and Fabricators,137,Heavy Assembler,51.137
 4994,51,9000,Other Production Occupations,139,Dimensional Inspector,51.139
-4995,51,9000,Other Production Occupations,140,Final Inspector,51.140
+4995,51,9000,Other Production Occupations,140,Final Inspector,51.14
 4996,51,1000,Supervisors of Production Workers,141,Molding Supervisor,51.141
 4997,51,6000,"Textile, Apparel, and Furnishings Workers",142,Sewer,51.142
 4998,51,9000,Other Production Occupations,143,Tube Bender,51.143
@@ -5003,7 +5003,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5001,51,9000,Other Production Occupations,147,Coating Operator,51.147
 5002,51,1000,Supervisors of Production Workers,148,Paint Supervisor,51.148
 5003,51,2000,Assemblers and Fabricators,149,Packaging Assembler,51.149
-5004,51,9000,Other Production Occupations,150,Assembly Inspector,51.150
+5004,51,9000,Other Production Occupations,150,Assembly Inspector,51.15
 5005,51,9000,Other Production Occupations,151,Quality Specialist (Production),51.151
 5006,51,9000,Other Production Occupations,152,Operator Lead,51.152
 5007,51,9000,Other Production Occupations,153,Manufacturing Worker,51.153
@@ -5013,7 +5013,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5011,51,6000,"Textile, Apparel, and Furnishings Workers",157,Upholsterer,51.157
 5012,51,9000,Other Production Occupations,158,Quality Lead (Production),51.158
 5013,51,6000,"Textile, Apparel, and Furnishings Workers",159,Setter,51.159
-5014,51,1000,Supervisors of Production Workers,160,CNC Supervisor,51.160
+5014,51,1000,Supervisors of Production Workers,160,CNC Supervisor,51.16
 5015,51,4000,Metal Workers and Plastic Workers,161,Polisher,51.161
 5016,51,9000,Other Production Occupations,162,Compounder,51.162
 5017,51,9000,Other Production Occupations,163,Blender,51.163
@@ -5031,32 +5031,32 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5029,51,9000,Other Production Occupations,779,Other Topics,51.779
 5030,51,8000,Plant and System Operators,30998,Utilities Operator,51.30998
 5031,51,6000,"Textile, Apparel, and Furnishings Workers",10226,Tailor,51.10226
-5032,51,2000,Assemblers and Fabricators,30390,Production Assistant (Production),51.30390
-5033,51,1000,Supervisors of Production Workers,30490,Processing Supervisor,51.30490
+5032,51,2000,Assemblers and Fabricators,30390,Production Assistant (Production),51.3039
+5033,51,1000,Supervisors of Production Workers,30490,Processing Supervisor,51.3049
 5034,51,5000,Printing Workers,11113,Printer Technician,51.11113
 5035,51,9000,Other Production Occupations,11138,Orthopedic Technician,51.11138
 5036,51,9000,Other Production Occupations,31243,Operations Processor,51.31243
-5037,51,4000,Metal Workers and Plastic Workers,10920,Mill Operator,51.10920
+5037,51,4000,Metal Workers and Plastic Workers,10920,Mill Operator,51.1092
 5038,51,9000,Other Production Occupations,10725,Measurement Technician,51.10725
 5039,51,4000,Metal Workers and Plastic Workers,10338,Manufacturing Operator,51.10338
 5040,51,4000,Metal Workers and Plastic Workers,10069,Machinist,51.10069
 5041,51,6000,"Textile, Apparel, and Furnishings Workers",30727,Laundry Attendant,51.30727
 5042,51,9000,Other Production Occupations,10638,Jeweler,51.10638
-5043,51,9000,Other Production Occupations,31010,General Labor Operations,51.31010
+5043,51,9000,Other Production Occupations,31010,General Labor Operations,51.3101
 5044,51,9000,Other Production Occupations,10519,Cutter,51.10519
 5045,51,9000,Other Production Occupations,30323,Quality Assurance (QA) Tester (Production),51.30323
 5046,51,9000,Other Production Occupations,30771,Quality Assurance (QA) Technician (Production),51.30771
 5047,51,9000,Other Production Occupations,11225,Quality Assurance (QA) Coordinator (Production),51.11225
 5048,51,9000,Other Production Occupations,31172,Washer (Production),51.31172
-5049,51,1000,Supervisors of Production Workers,30460,Technician Supervisor (Production),51.30460
+5049,51,1000,Supervisors of Production Workers,30460,Technician Supervisor (Production),51.3046
 5050,51,8000,Plant and System Operators,10383,Systems Operator (Production),51.10383
 5051,51,1000,Supervisors of Production Workers,31271,Planning Supervisor (Production),51.31271
 5052,51,1000,Supervisors of Production Workers,30544,Distribution Supervisor (Production),51.30544
 5053,51,1000,Supervisors of Production Workers,30561,Department Head (Production),51.30561
-5054,51,1000,Supervisors of Production Workers,31270,General Supervisor (Production),51.31270
+5054,51,1000,Supervisors of Production Workers,31270,General Supervisor (Production),51.3127
 5055,51,1000,Supervisors of Production Workers,30959,Floor Supervisor (Production),51.30959
 5056,51,9000,Other Production Occupations,30276,Foreman (Production),51.30276
-5057,51,1000,Supervisors of Production Workers,30610,Control Supervisor (Production),51.30610
+5057,51,1000,Supervisors of Production Workers,30610,Control Supervisor (Production),51.3061
 5058,51,1000,Supervisors of Production Workers,31373,Assistant Supervisor (Production),51.31373
 5059,51,1000,Supervisors of Production Workers,31476,Electrical Supervisor (Production),51.31476
 5060,51,1000,Supervisors of Production Workers,30616,Area Supervisor (Production),51.30616
@@ -5065,12 +5065,12 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5063,51,3000,Food Processing Workers,1065,Butcher,51.1065
 5064,51,6000,"Textile, Apparel, and Furnishings Workers",1128,Winder,51.1128
 5065,51,6000,"Textile, Apparel, and Furnishings Workers",1119,Quilter,51.1119
-5066,51,1000,Supervisors of Production Workers,1010,Operations Manager (Production),51.1010
+5066,51,1000,Supervisors of Production Workers,1010,Operations Manager (Production),51.101
 5067,51,9000,Other Production Occupations,1038,Goldsmith,51.1038
 5068,51,6000,"Textile, Apparel, and Furnishings Workers",1131,Spinner,51.1131
 5069,51,9000,Other Production Occupations,1073,Gemologist,51.1073
 5070,51,9000,Other Production Occupations,1094,Coater,51.1094
-5071,51,5000,Printing Workers,1040,Typesetter,51.1040
+5071,51,5000,Printing Workers,1040,Typesetter,51.104
 5072,51,9000,Other Production Occupations,1051,Engraver,51.1051
 5073,51,7000,Woodworkers,1104,Refinisher,51.1104
 5074,51,1000,Supervisors of Production Workers,1087,Head of Production,51.1087
@@ -5085,7 +5085,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5083,51,9000,Other Production Occupations,1053,Jewelry Designer,51.1053
 5084,51,1000,Supervisors of Production Workers,1061,Shop Manager (Production),51.1061
 5085,51,9000,Other Production Occupations,1142,Appraiser (Production),51.1142
-5086,51,3000,Food Processing Workers,1080,Trimmer,51.1080
+5086,51,3000,Food Processing Workers,1080,Trimmer,51.108
 5087,51,6000,"Textile, Apparel, and Furnishings Workers",1082,Weaver,51.1082
 5088,51,8000,Plant and System Operators,1093,Head Operator,51.1093
 5089,51,3000,Food Processing Workers,1102,Brewer,51.1102
@@ -5096,10 +5096,10 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5094,51,1000,Supervisors of Production Workers,1031,Quality Manager,51.1031
 5095,51,2000,Assemblers and Fabricators,1024,Builder,51.1024
 5096,51,7000,Woodworkers,1058,Furniture Restorer,51.1058
-5097,51,6000,"Textile, Apparel, and Furnishings Workers",1130,Knitter,51.1130
+5097,51,6000,"Textile, Apparel, and Furnishings Workers",1130,Knitter,51.113
 5098,51,9000,Other Production Occupations,1008,Winemaker,51.1008
 5099,51,4000,Metal Workers and Plastic Workers,1017,Patternmaker,51.1017
-5100,53,3000,Motor Vehicle Operators,0,Truck Driver,53.0
+5100,53,3000,Motor Vehicle Operators,0,Truck Driver,53
 5101,53,7000,Material Moving Workers,1,Driver Helper,53.1
 5102,53,3000,Motor Vehicle Operators,2,Delivery Driver,53.2
 5103,53,7000,Material Moving Workers,3,Material Handler (Transportation and Material Moving),53.3
@@ -5109,7 +5109,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5107,53,3000,Motor Vehicle Operators,7,Route Sales Representative,53.7
 5108,53,7000,Material Moving Workers,8,Laborer,53.8
 5109,53,3000,Motor Vehicle Operators,9,Bus Driver,53.9
-5110,53,7000,Material Moving Workers,10,Residential Driver,53.10
+5110,53,7000,Material Moving Workers,10,Residential Driver,53.1
 5111,53,7000,Material Moving Workers,11,Forklift Driver,53.11
 5112,53,3000,Motor Vehicle Operators,12,Catering Driver,53.12
 5113,53,1000,Supervisors of Transportation and Material Moving Workers,13,Warehouse Supervisor,53.13
@@ -5118,14 +5118,14 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5116,53,3000,Motor Vehicle Operators,16,Commercial Driver,53.16
 5117,53,3000,Motor Vehicle Operators,17,Tractor Trailer Driver,53.17
 5118,53,7000,Material Moving Workers,18,Dock Worker,53.18
-5119,53,7000,Material Moving Workers,20,Automotive Detailer,53.20
+5119,53,7000,Material Moving Workers,20,Automotive Detailer,53.2
 5120,53,1000,Supervisors of Transportation and Material Moving Workers,21,Transportation Supervisor,53.21
 5121,53,1000,Supervisors of Transportation and Material Moving Workers,22,Warehouse Manager (Transportation and Material Moving),53.22
 5122,53,3000,Motor Vehicle Operators,23,City Driver,53.23
 5123,53,3000,Motor Vehicle Operators,25,Line-Haul Driver,53.25
 5124,53,3000,Motor Vehicle Operators,26,Driver Trainee,53.26
 5125,53,7000,Material Moving Workers,28,Crane Operator (Transportation and Material Moving),53.28
-5126,53,1000,Supervisors of Transportation and Material Moving Workers,30,Transportation Manager (Transportation and Material Moving),53.30
+5126,53,1000,Supervisors of Transportation and Material Moving Workers,30,Transportation Manager (Transportation and Material Moving),53.3
 5127,53,3000,Motor Vehicle Operators,31,Route Sales Driver,53.31
 5128,53,3000,Motor Vehicle Operators,32,Shuttle Driver,53.32
 5129,53,3000,Motor Vehicle Operators,33,Warehouse Driver,53.33
@@ -5134,7 +5134,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5132,53,6000,Other Transportation Workers,36,Vehicle Service Attendant,53.36
 5133,53,3000,Motor Vehicle Operators,38,Regional Truck Driver,53.38
 5134,53,3000,Motor Vehicle Operators,39,Owner Operator,53.39
-5135,53,1000,Supervisors of Transportation and Material Moving Workers,40,Shipping Supervisor,53.40
+5135,53,1000,Supervisors of Transportation and Material Moving Workers,40,Shipping Supervisor,53.4
 5136,53,3000,Motor Vehicle Operators,41,Fuel Transport Driver,53.41
 5137,53,1000,Supervisors of Transportation and Material Moving Workers,42,Route Manager,53.42
 5138,53,7000,Material Moving Workers,43,Packer,53.43
@@ -5155,7 +5155,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5153,53,1000,Supervisors of Transportation and Material Moving Workers,63,Driver Manager,53.63
 5154,53,1000,Supervisors of Transportation and Material Moving Workers,67,Transportation Coordinator,53.67
 5155,53,3000,Motor Vehicle Operators,68,Product Delivery Specialist,53.68
-5156,53,1000,Supervisors of Transportation and Material Moving Workers,70,Distribution Center Manager,53.70
+5156,53,1000,Supervisors of Transportation and Material Moving Workers,70,Distribution Center Manager,53.7
 5157,53,1000,Supervisors of Transportation and Material Moving Workers,71,Shipping Manager,53.71
 5158,53,3000,Motor Vehicle Operators,73,Bulk Driver,53.73
 5159,53,7000,Material Moving Workers,74,Clamp Forklift Operator,53.74
@@ -5164,7 +5164,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5162,53,6000,Other Transportation Workers,77,Valet Attendant,53.77
 5163,53,1000,Supervisors of Transportation and Material Moving Workers,78,Dock Supervisor,53.78
 5164,53,7000,Material Moving Workers,79,Warehouse Coordinator,53.79
-5165,53,6000,Other Transportation Workers,80,Aircraft Inspector,53.80
+5165,53,6000,Other Transportation Workers,80,Aircraft Inspector,53.8
 5166,53,1000,Supervisors of Transportation and Material Moving Workers,83,Route Supervisor,53.83
 5167,53,4000,Rail Transportation Workers,84,Yard Jockey,53.84
 5168,53,1000,Supervisors of Transportation and Material Moving Workers,85,Freight Operations Supervisor,53.85
@@ -5182,7 +5182,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5180,53,6000,Other Transportation Workers,107,Fueler,53.107
 5181,53,3000,Motor Vehicle Operators,108,Transport Driver,53.108
 5182,53,3000,Motor Vehicle Operators,109,Non-Commercial Driver's License (Non-CDL) Driver,53.109
-5183,53,7000,Material Moving Workers,110,Warehouse Production Operator,53.110
+5183,53,7000,Material Moving Workers,110,Warehouse Production Operator,53.11
 5184,53,3000,Motor Vehicle Operators,112,Semi-Truck Driver,53.112
 5185,53,1000,Supervisors of Transportation and Material Moving Workers,113,Assistant Warehouse Manager,53.113
 5186,53,1000,Supervisors of Transportation and Material Moving Workers,114,Assistant Transportation Manager,53.114
@@ -5202,28 +5202,28 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5200,53,3000,Motor Vehicle Operators,30547,Delivery Leader,53.30547
 5201,53,3000,Motor Vehicle Operators,11318,Chauffeur,53.11318
 5202,53,7000,Material Moving Workers,31172,Washer (Transportation and Material Moving),53.31172
-5203,53,6000,Other Transportation Workers,10780,Transportation Technician (Transportation and Material Moving),53.10780
+5203,53,6000,Other Transportation Workers,10780,Transportation Technician (Transportation and Material Moving),53.1078
 5204,53,6000,Other Transportation Workers,31087,Traffic Coordinator (Transportation and Material Moving),53.31087
 5205,53,1000,Supervisors of Transportation and Material Moving Workers,31143,Task Leader (Transportation and Material Moving),53.31143
 5206,53,6000,Other Transportation Workers,30985,Safety Inspector (Transportation and Material Moving),53.30985
-5207,53,7000,Material Moving Workers,31020,Production Warehouse (Transportation and Material Moving),53.31020
+5207,53,7000,Material Moving Workers,31020,Production Warehouse (Transportation and Material Moving),53.3102
 5208,53,3000,Motor Vehicle Operators,30837,Independent Contractor (Transportation and Material Moving),53.30837
-5209,53,1000,Supervisors of Transportation and Material Moving Workers,31270,General Supervisor (Transportation and Material Moving),53.31270
+5209,53,1000,Supervisors of Transportation and Material Moving Workers,31270,General Supervisor (Transportation and Material Moving),53.3127
 5210,53,1000,Supervisors of Transportation and Material Moving Workers,30544,Distribution Supervisor (Transportation and Material Moving),53.30544
 5211,53,5000,Water Transportation Workers,30248,Controller (Transportation and Material Moving),53.30248
-5212,53,1000,Supervisors of Transportation and Material Moving Workers,30610,Control Supervisor (Transportation and Material Moving),53.30610
-5213,53,4000,Rail Transportation Workers,10380,Conductor (Transportation and Material Moving),53.10380
+5212,53,1000,Supervisors of Transportation and Material Moving Workers,30610,Control Supervisor (Transportation and Material Moving),53.3061
+5213,53,4000,Rail Transportation Workers,10380,Conductor (Transportation and Material Moving),53.1038
 5214,53,3000,Motor Vehicle Operators,10587,Transportation Aide (Transportation and Material Moving),53.10587
 5215,53,1000,Supervisors of Transportation and Material Moving Workers,30616,Area Supervisor (Transportation and Material Moving),53.30616
 5216,53,2000,Air Transportation Workers,1019,Airline Captain,53.1019
 5217,53,5000,Water Transportation Workers,1083,Skipper,53.1083
 5218,53,3000,Motor Vehicle Operators,1032,HGV/Large Goods Vehicle (LGV) Driver,53.1032
-5219,53,1000,Supervisors of Transportation and Material Moving Workers,1010,Operations Supervisor (Transportation and Material Moving),53.1010
-5220,53,6000,Other Transportation Workers,1170,Operations Assistant (Transportation and Material Moving),53.1170
+5219,53,1000,Supervisors of Transportation and Material Moving Workers,1010,Operations Supervisor (Transportation and Material Moving),53.101
+5220,53,6000,Other Transportation Workers,1170,Operations Assistant (Transportation and Material Moving),53.117
 5221,53,5000,Water Transportation Workers,1055,First Officer,53.1055
 5222,53,7000,Material Moving Workers,1141,Yeoman,53.1141
 5223,53,5000,Water Transportation Workers,1112,Charter Captain,53.1112
-5224,53,1000,Supervisors of Transportation and Material Moving Workers,1140,Materials Supervisor (Transportation and Material Moving),53.1140
+5224,53,1000,Supervisors of Transportation and Material Moving Workers,1140,Materials Supervisor (Transportation and Material Moving),53.114
 5225,53,5000,Water Transportation Workers,1086,Ship's Officer,53.1086
 5226,53,2000,Air Transportation Workers,1034,Air Traffic Controller,53.1034
 5227,53,2000,Air Transportation Workers,1046,Flight Chief,53.1046
@@ -5253,28 +5253,28 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5251,53,3000,Motor Vehicle Operators,1018,Dispatcher (Transportation and Material Moving),53.1018
 5252,53,3000,Motor Vehicle Operators,1073,Bus Operator,53.1073
 5253,53,2000,Air Transportation Workers,1038,Flight Commander,53.1038
-5254,53,5000,Water Transportation Workers,1040,Marine Officer (Transportation and Material Moving),53.1040
+5254,53,5000,Water Transportation Workers,1040,Marine Officer (Transportation and Material Moving),53.104
 5255,53,5000,Water Transportation Workers,1057,Fishing Captain,53.1057
 5256,53,5000,Water Transportation Workers,1082,Ship Captain,53.1082
-5257,53,5000,Water Transportation Workers,1070,Sailor,53.1070
+5257,53,5000,Water Transportation Workers,1070,Sailor,53.107
 5258,53,5000,Water Transportation Workers,1005,Deckhand (Transportation and Material Moving),53.1005
 5259,53,5000,Water Transportation Workers,1059,Marine Captain,53.1059
 5260,53,4000,Rail Transportation Workers,1062,Transportation Operator,53.1062
 5261,53,5000,Water Transportation Workers,1014,Navigator,53.1014
 5262,53,6000,Other Transportation Workers,2151,Purser,53.2151
-5263,55,1000,Military Officer Special and Tactical Operations Leaders,0,Commissioned Officer,55.0
+5263,55,1000,Military Officer Special and Tactical Operations Leaders,0,Commissioned Officer,55
 5264,55,1000,Military Officer Special and Tactical Operations Leaders,1,Center Standards and Incentives Officer,55.1
 5265,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,3,Radar Technician,55.3
 5266,55,1000,Military Officer Special and Tactical Operations Leaders,4,Military Officer,55.4
 5267,55,1000,Military Officer Special and Tactical Operations Leaders,6,Battalion Air Officer,55.6
-5268,55,1000,Military Officer Special and Tactical Operations Leaders,10,Military Analyst,55.10
+5268,55,1000,Military Officer Special and Tactical Operations Leaders,10,Military Analyst,55.1
 5269,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,11,Weapons Technician,55.11
 5270,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,13,Field Artillery Firefinder Radar Operator,55.13
 5271,55,1000,Military Officer Special and Tactical Operations Leaders,15,Combat Shooting and Tactical Vehicle Operations Instructor,55.15
 5272,55,1000,Military Officer Special and Tactical Operations Leaders,16,Targeting Officer,55.16
 5273,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,18,Airborne Sensor Operator,55.18
 5274,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,19,Security Forces Operations Analyst,55.19
-5275,55,1000,Military Officer Special and Tactical Operations Leaders,20,Air Force Checkmate Lead,55.20
+5275,55,1000,Military Officer Special and Tactical Operations Leaders,20,Air Force Checkmate Lead,55.2
 5276,55,1000,Military Officer Special and Tactical Operations Leaders,26,Tactical (TAC) Officer,55.26
 5277,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,28,Other Topics,55.28
 5278,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,30692,Unit Leader (Military Specific),55.30692
@@ -5283,7 +5283,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5281,55,1000,Military Officer Special and Tactical Operations Leaders,11363,Intelligence Officer (Military Specific),55.11363
 5282,55,1000,Military Officer Special and Tactical Operations Leaders,30595,Counterintelligence Officer (Military Specific),55.30595
 5283,55,1000,Military Officer Special and Tactical Operations Leaders,30679,Control Officer (Military Specific),55.30679
-5284,55,1000,Military Officer Special and Tactical Operations Leaders,10630,Armed Officer (Military Specific),55.10630
+5284,55,1000,Military Officer Special and Tactical Operations Leaders,10630,Armed Officer (Military Specific),55.1063
 5285,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1147,Weapon Technician,55.1147
 5286,55,1000,Military Officer Special and Tactical Operations Leaders,1013,Weapons Officer,55.1013
 5287,55,1000,Military Officer Special and Tactical Operations Leaders,1112,Gunnery Officer,55.1112
@@ -5305,8 +5305,8 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5303,55,1000,Military Officer Special and Tactical Operations Leaders,1161,Command Sergeant Major,55.1161
 5304,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1108,Army National Guard,55.1108
 5305,55,1000,Military Officer Special and Tactical Operations Leaders,1008,Field Officer,55.1008
-5306,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1120,Operations Supervisor (Military Specific),55.1120
-5307,55,1000,Military Officer Special and Tactical Operations Leaders,1010,Warfare Officer,55.1010
+5306,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1120,Operations Supervisor (Military Specific),55.112
+5307,55,1000,Military Officer Special and Tactical Operations Leaders,1010,Warfare Officer,55.101
 5308,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1203,Chemical Specialist,55.1203
 5309,55,1000,Military Officer Special and Tactical Operations Leaders,1039,Liaison Officer (Military Specific),55.1039
 5310,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1044,Sonar Technician,55.1044
@@ -5334,7 +5334,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5332,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1219,Pilot (Military Specific),55.1219
 5333,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1052,Squadron Leader,55.1052
 5334,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1126,Artillery Forward Observer,55.1126
-5335,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1050,Enlisted Soldier,55.1050
+5335,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1050,Enlisted Soldier,55.105
 5336,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1113,Artillery Cannoneer,55.1113
 5337,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1194,Grenadier,55.1194
 5338,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1058,Military Policeman,55.1058
@@ -5348,11 +5348,11 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5346,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1088,Army Leader,55.1088
 5347,55,1000,Military Officer Special and Tactical Operations Leaders,1211,Defense Coordinating Officer (DCO),55.1211
 5348,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1102,Reconnaissance Specialist,55.1102
-5349,55,1000,Military Officer Special and Tactical Operations Leaders,1190,Chief Petty Officer (CPO),55.1190
+5349,55,1000,Military Officer Special and Tactical Operations Leaders,1190,Chief Petty Officer (CPO),55.119
 5350,55,1000,Military Officer Special and Tactical Operations Leaders,1195,Command Duty Officer,55.1195
 5351,55,1000,Military Officer Special and Tactical Operations Leaders,1095,Communications Officer (Military Specific),55.1095
 5352,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1131,Sergeant First Class,55.1131
-5353,55,1000,Military Officer Special and Tactical Operations Leaders,1130,Leading Chief Petty Officer,55.1130
+5353,55,1000,Military Officer Special and Tactical Operations Leaders,1130,Leading Chief Petty Officer,55.113
 5354,55,1000,Military Officer Special and Tactical Operations Leaders,1078,Corporal of Marines,55.1078
 5355,55,1000,Military Officer Special and Tactical Operations Leaders,1122,Catapult and Arresting Gear Officer,55.1122
 5356,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1156,Firearms Specialist,55.1156
@@ -5367,20 +5367,20 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5365,55,1000,Military Officer Special and Tactical Operations Leaders,1201,Evaluation Officer,55.1201
 5366,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1037,Weapons Specialist,55.1037
 5367,55,1000,Military Officer Special and Tactical Operations Leaders,1145,Non-Commissioned Officer (NCO),55.1145
-5368,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1080,Combat Soldier,55.1080
+5368,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1080,Combat Soldier,55.108
 5369,55,1000,Military Officer Special and Tactical Operations Leaders,1073,United States Marine Corps (USMC) Officer,55.1073
 5370,55,1000,Military Officer Special and Tactical Operations Leaders,1046,Air Force Officer,55.1046
 5371,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1173,Chaplain (Military Specific),55.1173
-5372,55,1000,Military Officer Special and Tactical Operations Leaders,1040,Artillery Officer,55.1040
+5372,55,1000,Military Officer Special and Tactical Operations Leaders,1040,Artillery Officer,55.104
 5373,55,1000,Military Officer Special and Tactical Operations Leaders,1101,Air Battle Manager,55.1101
 5374,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1033,Weapons and Tactics Instructor,55.1033
-5375,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1110,Army Specialist,55.1110
+5375,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1110,Army Specialist,55.111
 5376,55,1000,Military Officer Special and Tactical Operations Leaders,1038,Signal Officer,55.1038
 5377,55,2000,First-Line Enlisted Military Supervisors,1129,Wing Weapons Manager,55.1129
 5378,55,1000,Military Officer Special and Tactical Operations Leaders,1215,Senior Non-Commissioned Officer (SNCO),55.1215
-5379,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1070,Chief of Staff,55.1070
+5379,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1070,Chief of Staff,55.107
 5380,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1202,Private Soldier,55.1202
-5381,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1090,Crewman (Military Specific),55.1090
+5381,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1090,Crewman (Military Specific),55.109
 5382,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1139,Brigade S4,55.1139
 5383,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1093,Cadet,55.1093
 5384,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1167,Naval Aviator,55.1167
@@ -5391,7 +5391,7 @@ ID,Major,Minor,MinorTitle,GroupId,GroupTitle,CID
 5389,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1121,Captain (Military Specific),55.1121
 5390,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1015,Gunner,55.1015
 5391,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1006,Platoon Leader,55.1006
-5392,55,1000,Military Officer Special and Tactical Operations Leaders,1160,Special Forces Officer,55.1160
+5392,55,1000,Military Officer Special and Tactical Operations Leaders,1160,Special Forces Officer,55.116
 5393,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1045,Combat Instructor,55.1045
 5394,55,3000,Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members,1119,Royal Marines Commando,55.1119
 5395,55,1000,Military Officer Special and Tactical Operations Leaders,1035,Mobility Officer,55.1035


### PR DESCRIPTION
**Purpose**
* Introduces a quick-and-dirty migration to find and replace incorrect Carotene Codes (trailing 0s were being lopped off)
* This migration reads each line of the old, incorrect Carotene CSV and uses the row's ID to match with the new, correct CSV. It then replaces the incorrect CID with the corrected one and saves.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-612

**Changes**
* Improvements and fixes
  * N/A

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * Yes, there is a migration that finds/replaces records. Please remember to run migration!
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A

* After
N/A

**Feature Server**
http://web.cortex-2.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * Ensure Carotene Codes have correct CIDs/`code`s. For example, there should be a Carotene with a `code` of `49.30` that has a title `Automotive Technician`.

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies**
  * N/A

**Additional Information**
N/A